### PR TITLE
fix: Add explicit time-outs to the HTTP Clients

### DIFF
--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/HttpAsyncClientSupplier.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/HttpAsyncClientSupplier.java
@@ -16,9 +16,14 @@
  */
 package io.github.jeremylong.openvulnerability.client;
 
+import org.apache.hc.client5.http.config.ConnectionConfig;
 import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
 import org.apache.hc.client5.http.impl.async.HttpAsyncClients;
+import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManager;
+import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManagerBuilder;
 import org.apache.hc.client5.http.impl.routing.SystemDefaultRoutePlanner;
+import org.apache.hc.core5.util.TimeValue;
+import org.apache.hc.core5.util.Timeout;
 
 import java.net.ProxySelector;
 import java.util.function.Supplier;
@@ -36,7 +41,14 @@ public interface HttpAsyncClientSupplier extends Supplier<CloseableHttpAsyncClie
     static HttpAsyncClientSupplier getDefault() {
         return () -> {
             SystemDefaultRoutePlanner planner = new SystemDefaultRoutePlanner(ProxySelector.getDefault());
-            return HttpAsyncClients.custom().setRoutePlanner(planner).useSystemProperties().build();
+            final PoolingAsyncClientConnectionManager connectionManager = PoolingAsyncClientConnectionManagerBuilder.create()
+                    .setDefaultConnectionConfig(ConnectionConfig.custom()
+                            .setSocketTimeout(Timeout.ofMinutes(1))
+                            .setConnectTimeout(Timeout.ofMinutes(1))
+                            .build())
+                    .useSystemProperties()
+                    .build();
+            return HttpAsyncClients.custom().setRoutePlanner(planner).setConnectionManager(connectionManager).useSystemProperties().build();
         };
     }
 

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/HttpAsyncClientSupplier.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/HttpAsyncClientSupplier.java
@@ -41,14 +41,12 @@ public interface HttpAsyncClientSupplier extends Supplier<CloseableHttpAsyncClie
     static HttpAsyncClientSupplier getDefault() {
         return () -> {
             SystemDefaultRoutePlanner planner = new SystemDefaultRoutePlanner(ProxySelector.getDefault());
-            final PoolingAsyncClientConnectionManager connectionManager = PoolingAsyncClientConnectionManagerBuilder.create()
-                    .setDefaultConnectionConfig(ConnectionConfig.custom()
-                            .setSocketTimeout(Timeout.ofMinutes(1))
-                            .setConnectTimeout(Timeout.ofMinutes(1))
-                            .build())
-                    .useSystemProperties()
-                    .build();
-            return HttpAsyncClients.custom().setRoutePlanner(planner).setConnectionManager(connectionManager).useSystemProperties().build();
+            final PoolingAsyncClientConnectionManager connectionManager = PoolingAsyncClientConnectionManagerBuilder
+                    .create().setDefaultConnectionConfig(ConnectionConfig.custom()
+                            .setSocketTimeout(Timeout.ofMinutes(1)).setConnectTimeout(Timeout.ofMinutes(1)).build())
+                    .useSystemProperties().build();
+            return HttpAsyncClients.custom().setRoutePlanner(planner).setConnectionManager(connectionManager)
+                    .useSystemProperties().build();
         };
     }
 

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/RateLimitedClient.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/RateLimitedClient.java
@@ -19,10 +19,15 @@ package io.github.jeremylong.openvulnerability.client.nvd;
 import io.github.jeremylong.openvulnerability.client.HttpAsyncClientSupplier;
 import org.apache.hc.client5.http.async.methods.SimpleHttpRequest;
 import org.apache.hc.client5.http.async.methods.SimpleHttpResponse;
+import org.apache.hc.client5.http.config.ConnectionConfig;
 import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
 import org.apache.hc.client5.http.impl.async.HttpAsyncClients;
+import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManager;
+import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManagerBuilder;
 import org.apache.hc.client5.http.impl.routing.SystemDefaultRoutePlanner;
 import org.apache.hc.core5.concurrent.FutureCallback;
+import org.apache.hc.core5.util.TimeValue;
+import org.apache.hc.core5.util.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -128,7 +133,16 @@ class RateLimitedClient implements AutoCloseable {
         if (httpClientSupplier == null) {
             NvdApiRetryStrategy retryStrategy = new NvdApiRetryStrategy(maxRetries, minimumDelay);
             SystemDefaultRoutePlanner planner = new SystemDefaultRoutePlanner(ProxySelector.getDefault());
+            final PoolingAsyncClientConnectionManager connectionManager = PoolingAsyncClientConnectionManagerBuilder.create()
+                    .setDefaultConnectionConfig(ConnectionConfig.custom()
+                            .setSocketTimeout(Timeout.ofMinutes(1))
+                            .setConnectTimeout(Timeout.ofMinutes(1))
+                            .build())
+                    .useSystemProperties()
+                    .build();
+
             client = HttpAsyncClients.custom().setRoutePlanner(planner).setRetryStrategy(retryStrategy)
+                    .setConnectionManager(connectionManager)
                     .useSystemProperties().build();
         } else {
             client = httpClientSupplier.get();

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/RateLimitedClient.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/RateLimitedClient.java
@@ -133,17 +133,13 @@ class RateLimitedClient implements AutoCloseable {
         if (httpClientSupplier == null) {
             NvdApiRetryStrategy retryStrategy = new NvdApiRetryStrategy(maxRetries, minimumDelay);
             SystemDefaultRoutePlanner planner = new SystemDefaultRoutePlanner(ProxySelector.getDefault());
-            final PoolingAsyncClientConnectionManager connectionManager = PoolingAsyncClientConnectionManagerBuilder.create()
-                    .setDefaultConnectionConfig(ConnectionConfig.custom()
-                            .setSocketTimeout(Timeout.ofMinutes(1))
-                            .setConnectTimeout(Timeout.ofMinutes(1))
-                            .build())
-                    .useSystemProperties()
-                    .build();
+            final PoolingAsyncClientConnectionManager connectionManager = PoolingAsyncClientConnectionManagerBuilder
+                    .create().setDefaultConnectionConfig(ConnectionConfig.custom()
+                            .setSocketTimeout(Timeout.ofMinutes(1)).setConnectTimeout(Timeout.ofMinutes(1)).build())
+                    .useSystemProperties().build();
 
             client = HttpAsyncClients.custom().setRoutePlanner(planner).setRetryStrategy(retryStrategy)
-                    .setConnectionManager(connectionManager)
-                    .useSystemProperties().build();
+                    .setConnectionManager(connectionManager).useSystemProperties().build();
         } else {
             client = httpClientSupplier.get();
         }


### PR DESCRIPTION
@jeremylong This is my attempt to also get timeouts configured in the open-vulnerability-clients. I chose not to make them configurable, that could be done as an extension to this. It should at least prevent connections from hanging indefinitely as they will time-out on connnection attempts as well as on communication after 1 minute.

Should fix the issue reported in ODC on completely hanging communication to the NVD API (https://github.com/dependency-check/DependencyCheck/issues/7418).

Adds the timeouts both to the HttpClient connections for NVD API as well as for the various other sources.