### PR TITLE
fix: Prevent index-out-of-bound on too short API key

### DIFF
--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/NvdCveClient.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/NvdCveClient.java
@@ -439,13 +439,17 @@ public class NvdCveClient implements PagedDataSource<DefCveItem> {
                     if (msg != null) {
                         msg = msg.trim();
                         if (msg.contains("Invalid apiKey")) {
+                            String masked;
                             if (this.apiKey.length() > 30) {
-                                String masked = String.format("Invalid API Key: %s-*****-%s",
-                                        this.apiKey.substring(0, 5),
+                                masked = String.format("Invalid API Key: %s-*****-%s", this.apiKey.substring(0, 5),
                                         this.apiKey.substring(this.apiKey.length() - 5, this.apiKey.length()));
-                                throw new NvdApiException(masked);
+                            } else if (this.apiKey.length() < 5) {
+                                masked = String.format(
+                                        "Invalid API Key, length of %d too short to provided a masked partial key",
+                                        this.apiKey.length());
+                            } else {
+                                masked = String.format("Invalid API Key: %s-*****", this.apiKey.substring(0, 5));
                             }
-                            String masked = String.format("Invalid API Key: %s-*****", this.apiKey.substring(0, 5));
                             throw new NvdApiException(masked);
                         } else if (msg.startsWith("resultsPerPage parameter cannot exceed")) {
                             this.resultsPerPage = parseResultsPerPage(msg);


### PR DESCRIPTION
Extend the messages for invalid API key preventing the StringIndexOutOfBoundsException on API keys with a value smaller than 5 characters.

fixes #5