### PR TITLE
fix: allow trailing commas in JSON arrays

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version = 7.3.1
+version = 7.3.2

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/NvdCveClient.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/NvdCveClient.java
@@ -16,6 +16,7 @@
  */
 package io.github.jeremylong.openvulnerability.client.nvd;
 
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -246,6 +247,7 @@ public class NvdCveClient implements PagedDataSource<DefCveItem> {
             clients.add(new RateLimitedClient(maxRetryCount, delay, meter, httpClientSupplier, cacheDirectory));
         }
         objectMapper = new ObjectMapper();
+        objectMapper.configure(JsonParser.Feature.ALLOW_TRAILING_COMMA, true);
         objectMapper.registerModule(new JavaTimeModule());
 
         try {


### PR DESCRIPTION
Configure Jackson to allow trailing commas:
- fixes https://github.com/jeremylong/open-vulnerability-cli/issues/306 
- fixes https://github.com/dependency-check/DependencyCheck/issues/7576