### PR TITLE
feat!: Requests Per 30-Second rolling window instead of threatCount+delay

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version = 7.3.3-SNAPSHOT
+version = 8.0.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version = 7.3.2
+version = 7.3.3-SNAPSHOT

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/NvdCveClient.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/NvdCveClient.java
@@ -16,8 +16,8 @@
  */
 package io.github.jeremylong.openvulnerability.client.nvd;
 
-import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.json.JsonReadFeature;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -144,11 +144,11 @@ public class NvdCveClient implements PagedDataSource<DefCveItem> {
      * @param apiKey the api key; can be null
      * @param endpoint the endpoint for the NVD CVE API; if null the default endpoint is used
      * @param maxPageCount the maximum number of pages to retrieve from the NVD API.
-     * @param requestsPerMinute the number of requests per minute allowed. The NVD's published rate limits are 10
-     *     requests per minute without an API Key and 100 requests per minute with an API Key.
+     * @param requestsPerThirtySeconds the number of requests per 30-seconds allowed. The NVD's published rate limits
+     *     are 5 requests per 30-seconds without an API Key and 50 requests per 30-seconds with an API Key.
      */
-    NvdCveClient(String apiKey, String endpoint, int maxPageCount, int requestsPerMinute) {
-        this(apiKey, endpoint, maxPageCount, 10, requestsPerMinute);
+    NvdCveClient(String apiKey, String endpoint, int maxPageCount, int requestsPerThirtySeconds) {
+        this(apiKey, endpoint, maxPageCount, 10, requestsPerThirtySeconds);
     }
 
     /**
@@ -158,11 +158,11 @@ public class NvdCveClient implements PagedDataSource<DefCveItem> {
      * @param endpoint the endpoint for the NVD CVE API; if null the default endpoint is used
      * @param maxPageCount the maximum number of pages to retrieve from the NVD API.
      * @param maxRetryCount the maximum number of retries for 503 and 429 status code responses.
-     * @param requestsPerMinute the number of requests per minute allowed. The NVD's published rate limits are 10
-     *     requests per minute without an API Key and 100 requests per minute with an API Key.
+     * @param requestsPerThirtySeconds the number of requests per 30-seconds allowed. The NVD's published rate limits
+     *     are 5 requests per 30-seconds without an API Key and 50 requests per 30-seconds with an API Key.
      */
-    NvdCveClient(String apiKey, String endpoint, int maxPageCount, int maxRetryCount, int requestsPerMinute) {
-        this(apiKey, endpoint, 0, maxPageCount, maxRetryCount, null, requestsPerMinute);
+    NvdCveClient(String apiKey, String endpoint, int maxPageCount, int maxRetryCount, int requestsPerThirtySeconds) {
+        this(apiKey, endpoint, 0, maxPageCount, maxRetryCount, null, requestsPerThirtySeconds);
     }
 
     /**
@@ -174,12 +174,12 @@ public class NvdCveClient implements PagedDataSource<DefCveItem> {
      * @param maxPageCount the maximum number of pages to retrieve from the NVD API.
      * @param maxRetryCount the maximum number of retries for 503 and 429 status code responses.
      * @param httpClientSupplier supplier for custom HTTP clients; if {@code null} a default client will be used
-     * @param requestsPerMinute the number of requests per minute allowed. The NVD's published rate limits are 10
-     *     requests per minute without an API Key and 100 requests per minute with an API Key.
+     * @param requestsPerThirtySeconds the number of requests per 30-seconds allowed. The NVD's published rate limits
+     *     are 5 requests per 30-seconds without an API Key and 50 requests per 30-seconds with an API Key.
      */
     NvdCveClient(String apiKey, String endpoint, long delay, int maxPageCount, int maxRetryCount,
-            HttpAsyncClientSupplier httpClientSupplier, int requestsPerMinute) {
-        this(apiKey, endpoint, delay, maxPageCount, maxRetryCount, httpClientSupplier, null, requestsPerMinute);
+            HttpAsyncClientSupplier httpClientSupplier, int requestsPerThirtySeconds) {
+        this(apiKey, endpoint, delay, maxPageCount, maxRetryCount, httpClientSupplier, null, requestsPerThirtySeconds);
     }
 
     /**
@@ -192,13 +192,13 @@ public class NvdCveClient implements PagedDataSource<DefCveItem> {
      * @param maxRetryCount the maximum number of retries for 503 and 429 status code responses.
      * @param httpClientSupplier supplier for custom HTTP clients; if {@code null} a default client will be used
      * @param userAgent the user agent to append to the default open-vulnerability-client's user-agent string
-     * @param requestsPerMinute the number of requests per minute allowed. The NVD's published rate limits are 10
-     *     requests per minute without an API Key and 100 requests per minute with an API Key.
+     * @param requestsPerThirtySeconds the number of requests per 30-seconds allowed. The NVD's published rate limits
+     *     are 5 requests per 30-seconds without an API Key and 50 requests per 30-seconds with an API Key.
      */
     NvdCveClient(String apiKey, String endpoint, long delay, int maxPageCount, int maxRetryCount,
-            HttpAsyncClientSupplier httpClientSupplier, String userAgent, int requestsPerMinute) {
+            HttpAsyncClientSupplier httpClientSupplier, String userAgent, int requestsPerThirtySeconds) {
         this(apiKey, endpoint, delay, maxPageCount, maxRetryCount, httpClientSupplier, userAgent, null,
-                requestsPerMinute);
+                requestsPerThirtySeconds);
     }
 
     /**
@@ -213,35 +213,20 @@ public class NvdCveClient implements PagedDataSource<DefCveItem> {
      * @param userAgent the user agent to append to the default open-vulnerability-client's user-agent string.
      * @param cacheDirectory the directory to store the NVD API HTTP response cache; if {@code null} the requests will
      *     not be cached.
-     * @param requestsPerMinute the number of requests per minute allowed. The NVD's published rate limits are 10
-     *     requests per minute without an API Key and 100 requests per minute with an API Key.
+     * @param requestsPerThirtySeconds the number of requests per 30-seconds allowed. The NVD's published rate limits
+     *     are 5 requests per 30-seconds without an API Key and 50 requests per 30-seconds with an API Key.
      */
     NvdCveClient(String apiKey, String endpoint, long delay, int maxPageCount, int maxRetryCount,
-            HttpAsyncClientSupplier httpClientSupplier, String userAgent, Path cacheDirectory, int requestsPerMinute) {
+            HttpAsyncClientSupplier httpClientSupplier, String userAgent, Path cacheDirectory,
+            int requestsPerThirtySeconds) {
         this.apiKey = apiKey;
         this.userAgent = userAgent;
-        if (endpoint == null) {
-            this.endpoint = DEFAULT_ENDPOINT;
-        } else {
-            this.endpoint = endpoint;
-        }
+        this.endpoint = endpoint == null ? DEFAULT_ENDPOINT : endpoint;
         this.maxPageCount = maxPageCount;
-        // configure the rate limit slightly higher than the published limits:
-        // https://nvd.nist.gov/developers/start-here (see Rate Limits)
-        RateMeter meter;
-        if (requestsPerMinute > 0) {
-            meter = new RateMeter(requestsPerMinute, 60500);
-        } else if (apiKey == null) {
-            meter = new RateMeter(5, 30500);
-        } else {
-            meter = new RateMeter(50, 30500);
-        }
-        if (delay == 0) {
-            delay = meter.getQuantity() / meter.getDuration();
-        }
-        rlClient = new RateLimitedClient(maxRetryCount, delay, meter, httpClientSupplier, cacheDirectory);
+        rlClient = new RateLimitedClient(maxRetryCount, delay, requestsPerThirtySeconds, httpClientSupplier,
+                cacheDirectory, apiKey != null);
         objectMapper = new ObjectMapper();
-        objectMapper.configure(JsonParser.Feature.ALLOW_TRAILING_COMMA, true);
+        objectMapper.configure(JsonReadFeature.ALLOW_TRAILING_COMMA.mappedFeature(), true);
         objectMapper.registerModule(new JavaTimeModule());
 
         try {
@@ -326,7 +311,7 @@ public class NvdCveClient implements PagedDataSource<DefCveItem> {
     @Override
     public void close() {
         indexesToRetrieve.clear();
-        if (futures.size() > 0) {
+        if (!futures.isEmpty()) {
             for (Future<RateLimitedCall> future : futures) {
                 if (!future.isDone()) {
                     future.cancel(true);
@@ -424,7 +409,7 @@ public class NvdCveClient implements PagedDataSource<DefCveItem> {
                     Header[] headers = response.getHeaders();
                     String msg = null;
                     for (Header header : headers) {
-                        LOG.debug("Key : " + header.getName() + " ,Value : " + header.getValue());
+                        LOG.debug("Key : {} ,Value : {}", header.getName(), header.getValue());
                         if ("message".equals(header.getName())) {
                             msg = header.getValue();
                         }
@@ -436,7 +421,7 @@ public class NvdCveClient implements PagedDataSource<DefCveItem> {
                             String masked;
                             if (this.apiKey.length() > 30) {
                                 masked = String.format("Invalid API Key: %s-*****-%s", this.apiKey.substring(0, 5),
-                                        this.apiKey.substring(this.apiKey.length() - 5, this.apiKey.length()));
+                                        this.apiKey.substring(this.apiKey.length() - 5));
                             } else if (this.apiKey.length() < 5) {
                                 masked = String.format(
                                         "Invalid API Key, length of %d too short to provided a masked partial key",
@@ -485,7 +470,7 @@ public class NvdCveClient implements PagedDataSource<DefCveItem> {
         try {
             return Integer.parseInt(value);
         } catch (NumberFormatException e) {
-            LOG.debug("Error parsing " + msg, e);
+            LOG.debug("Error parsing {}", msg, e);
         }
         return resultsPerPage;
     }

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/NvdCveClient.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/NvdCveClient.java
@@ -95,7 +95,7 @@ public class NvdCveClient implements PagedDataSource<DefCveItem> {
     /**
      * The rate limited HTTP client for calling the NVD APIs.
      */
-    private List<RateLimitedClient> clients;
+    private RateLimitedClient rlClient;
     /**
      * The list of future responses.
      */
@@ -212,7 +212,6 @@ public class NvdCveClient implements PagedDataSource<DefCveItem> {
      */
     NvdCveClient(String apiKey, String endpoint, long delay, int threadCount, int maxPageCount, int maxRetryCount,
             HttpAsyncClientSupplier httpClientSupplier, String userAgent, Path cacheDirectory) {
-
         this.apiKey = apiKey;
         this.userAgent = userAgent;
         if (endpoint == null) {
@@ -229,23 +228,28 @@ public class NvdCveClient implements PagedDataSource<DefCveItem> {
 
         RateMeter meter;
         if (apiKey == null) {
-            if (threadCount > 1) {
-                LOG.warn(
-                        "No api key provided; as such the thread count has been reset to 1 instead of the requested {}",
-                        threadCount);
-                threadCount = 1;
-            }
-            meter = new RateMeter(5, 32500);
+            // if (threadCount > 1) {
+            // LOG.warn(
+            // "No api key provided; as such the thread count has been reset to 1 instead of the requested {}",
+            // threadCount);
+            // threadCount = 1;
+            // }
+            int asyncCallCount = 5;
+            // if (callsPerThread != null && callsPerThread > 0) {
+            // asyncCallCount = callsPerThread;
+            // }
+            meter = new RateMeter(asyncCallCount, 32500);
         } else {
-            meter = new RateMeter(50, 32500);
+            int asyncCallCount = 50;
+            // if (callsPerThread != null && callsPerThread > 0) {
+            // asyncCallCount = callsPerThread;
+            // }
+            meter = new RateMeter(asyncCallCount, 32500);
         }
-        clients = new ArrayList<>(threadCount);
         if (delay == 0) {
             delay = apiKey == null ? 6500 : 600;
         }
-        for (int i = 0; i < threadCount; i++) {
-            clients.add(new RateLimitedClient(maxRetryCount, delay, meter, httpClientSupplier, cacheDirectory));
-        }
+        rlClient = new RateLimitedClient(maxRetryCount, delay, meter, httpClientSupplier, cacheDirectory);
         objectMapper = new ObjectMapper();
         objectMapper.configure(JsonParser.Feature.ALLOW_TRAILING_COMMA, true);
         objectMapper.registerModule(new JavaTimeModule());
@@ -303,7 +307,7 @@ public class NvdCveClient implements PagedDataSource<DefCveItem> {
      * @return the future
      * @throws NvdApiException thrown if there is a problem calling the API
      */
-    private Future<RateLimitedCall> callApi(int clientIndex, int startIndex) throws NvdApiException {
+    private Future<RateLimitedCall> callApi(int startIndex) throws NvdApiException {
         try {
             URIBuilder uriBuilder = new URIBuilder(endpoint);
             if (filters != null) {
@@ -323,7 +327,7 @@ public class NvdCveClient implements PagedDataSource<DefCveItem> {
             URI uri = uriBuilder.build();
             LOG.debug("requesting URI: {}", uri.toString());
             final SimpleHttpRequest request = builder.setUri(uri).build();
-            return clients.get(clientIndex).execute(request, clientIndex, startIndex);
+            return rlClient.execute(request, startIndex);
         } catch (URISyntaxException e) {
             throw new NvdApiException(e);
         }
@@ -340,15 +344,13 @@ public class NvdCveClient implements PagedDataSource<DefCveItem> {
             }
             futures.clear();
         }
-        if (clients != null) {
-            for (RateLimitedClient client : clients) {
-                try {
-                    client.close();
-                } catch (Exception ex) {
-                    LOG.debug("Error closing client during `close`", ex);
-                }
+        if (rlClient != null) {
+            try {
+                rlClient.close();
+            } catch (Exception ex) {
+                LOG.debug("Error closing client during `close`", ex);
             }
-            clients = null;
+            rlClient = null;
         }
     }
 
@@ -385,7 +387,7 @@ public class NvdCveClient implements PagedDataSource<DefCveItem> {
                     "NVD Update Failed: attempted to retrieve data from the NVD unsuccessfully five times.");
         }
         if (firstCall) {
-            futures.add(callApi(0, 0));
+            futures.add(callApi(0));
         }
         String json;
         RateLimitedCall call;
@@ -541,34 +543,24 @@ public class NvdCveClient implements PagedDataSource<DefCveItem> {
     }
 
     private void queueUnsuccessful() {
-        int clientIndex = 0;
         for (Map.Entry<Integer, Integer> i : indexesToRetrieve.entrySet()) {
             if (i.getValue() > 5) {
                 throw new NvdApiRetryExceededException("NVD Update Failed: attempted to retrieve starting index "
                         + i.getKey() + " from the NVD unsuccessfully five times.");
             }
             i.setValue(i.getValue() + 1);
-            futures.add(callApi(clientIndex, i.getKey()));
-            clientIndex += 1;
-            if (clientIndex >= clients.size()) {
-                clientIndex = 0;
-            }
+            futures.add(callApi(i.getKey()));
         }
     }
 
     private void queueCalls() {
-        int clientIndex = 0;
         int pageCount = 1;
         // start at results per page - as 0 was already requested
         for (int i = resultsPerPage; (maxPageCount <= 0 || pageCount < maxPageCount)
                 && i < totalAvailable; i += resultsPerPage) {
             indexesToRetrieve.put(i, 0);
-            futures.add(callApi(clientIndex, i));
+            futures.add(callApi(i));
             pageCount += 1;
-            clientIndex += 1;
-            if (clientIndex >= clients.size()) {
-                clientIndex = 0;
-            }
         }
     }
 }

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/NvdCveClient.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/NvdCveClient.java
@@ -143,11 +143,12 @@ public class NvdCveClient implements PagedDataSource<DefCveItem> {
      *
      * @param apiKey the api key; can be null
      * @param endpoint the endpoint for the NVD CVE API; if null the default endpoint is used
-     * @param threadCount the number of threads to use when calling the NVD API.
      * @param maxPageCount the maximum number of pages to retrieve from the NVD API.
+     * @param requestsPerMinute the number of requests per minute allowed. The NVD's published rate limits are 10
+     *     requests per minute without an API Key and 100 requests per minute with an API Key.
      */
-    NvdCveClient(String apiKey, String endpoint, int threadCount, int maxPageCount) {
-        this(apiKey, endpoint, 0, threadCount, maxPageCount, 10, null);
+    NvdCveClient(String apiKey, String endpoint, int maxPageCount, int requestsPerMinute) {
+        this(apiKey, endpoint, maxPageCount, 10, requestsPerMinute);
     }
 
     /**
@@ -155,12 +156,13 @@ public class NvdCveClient implements PagedDataSource<DefCveItem> {
      *
      * @param apiKey the api key; can be null
      * @param endpoint the endpoint for the NVD CVE API; if null the default endpoint is used
-     * @param threadCount the number of threads to use when calling the NVD API.
      * @param maxPageCount the maximum number of pages to retrieve from the NVD API.
      * @param maxRetryCount the maximum number of retries for 503 and 429 status code responses.
+     * @param requestsPerMinute the number of requests per minute allowed. The NVD's published rate limits are 10
+     *     requests per minute without an API Key and 100 requests per minute with an API Key.
      */
-    NvdCveClient(String apiKey, String endpoint, int threadCount, int maxPageCount, int maxRetryCount) {
-        this(apiKey, endpoint, 0, threadCount, maxPageCount, maxRetryCount, null);
+    NvdCveClient(String apiKey, String endpoint, int maxPageCount, int maxRetryCount, int requestsPerMinute) {
+        this(apiKey, endpoint, 0, maxPageCount, maxRetryCount, null, requestsPerMinute);
     }
 
     /**
@@ -169,14 +171,15 @@ public class NvdCveClient implements PagedDataSource<DefCveItem> {
      * @param apiKey the api key; can be null
      * @param endpoint the endpoint for the NVD CVE API; if null the default endpoint is used
      * @param delay the delay in milliseconds between API calls on a single thread.
-     * @param threadCount the number of threads to use when calling the NVD API.
      * @param maxPageCount the maximum number of pages to retrieve from the NVD API.
      * @param maxRetryCount the maximum number of retries for 503 and 429 status code responses.
      * @param httpClientSupplier supplier for custom HTTP clients; if {@code null} a default client will be used
+     * @param requestsPerMinute the number of requests per minute allowed. The NVD's published rate limits are 10
+     *     requests per minute without an API Key and 100 requests per minute with an API Key.
      */
-    NvdCveClient(String apiKey, String endpoint, long delay, int threadCount, int maxPageCount, int maxRetryCount,
-            HttpAsyncClientSupplier httpClientSupplier) {
-        this(apiKey, endpoint, delay, threadCount, maxPageCount, maxRetryCount, httpClientSupplier, null);
+    NvdCveClient(String apiKey, String endpoint, long delay, int maxPageCount, int maxRetryCount,
+            HttpAsyncClientSupplier httpClientSupplier, int requestsPerMinute) {
+        this(apiKey, endpoint, delay, maxPageCount, maxRetryCount, httpClientSupplier, null, requestsPerMinute);
     }
 
     /**
@@ -185,15 +188,17 @@ public class NvdCveClient implements PagedDataSource<DefCveItem> {
      * @param apiKey the api key; can be null
      * @param endpoint the endpoint for the NVD CVE API; if null the default endpoint is used
      * @param delay the delay in milliseconds between API calls on a single thread.
-     * @param threadCount the number of threads to use when calling the NVD API.
      * @param maxPageCount the maximum number of pages to retrieve from the NVD API.
      * @param maxRetryCount the maximum number of retries for 503 and 429 status code responses.
      * @param httpClientSupplier supplier for custom HTTP clients; if {@code null} a default client will be used
      * @param userAgent the user agent to append to the default open-vulnerability-client's user-agent string
+     * @param requestsPerMinute the number of requests per minute allowed. The NVD's published rate limits are 10
+     *     requests per minute without an API Key and 100 requests per minute with an API Key.
      */
-    NvdCveClient(String apiKey, String endpoint, long delay, int threadCount, int maxPageCount, int maxRetryCount,
-            HttpAsyncClientSupplier httpClientSupplier, String userAgent) {
-        this(apiKey, endpoint, delay, threadCount, maxPageCount, maxRetryCount, httpClientSupplier, userAgent, null);
+    NvdCveClient(String apiKey, String endpoint, long delay, int maxPageCount, int maxRetryCount,
+            HttpAsyncClientSupplier httpClientSupplier, String userAgent, int requestsPerMinute) {
+        this(apiKey, endpoint, delay, maxPageCount, maxRetryCount, httpClientSupplier, userAgent, null,
+                requestsPerMinute);
     }
 
     /**
@@ -202,16 +207,17 @@ public class NvdCveClient implements PagedDataSource<DefCveItem> {
      * @param apiKey the api key; can be null
      * @param endpoint the endpoint for the NVD CVE API; if null the default endpoint is used
      * @param delay the delay in milliseconds between API calls on a single thread.
-     * @param threadCount the number of threads to use when calling the NVD API.
      * @param maxPageCount the maximum number of pages to retrieve from the NVD API.
      * @param maxRetryCount the maximum number of retries for 503 and 429 status code responses.
      * @param httpClientSupplier supplier for custom HTTP clients; if {@code null} a default client will be used.
      * @param userAgent the user agent to append to the default open-vulnerability-client's user-agent string.
      * @param cacheDirectory the directory to store the NVD API HTTP response cache; if {@code null} the requests will
      *     not be cached.
+     * @param requestsPerMinute the number of requests per minute allowed. The NVD's published rate limits are 10
+     *     requests per minute without an API Key and 100 requests per minute with an API Key.
      */
-    NvdCveClient(String apiKey, String endpoint, long delay, int threadCount, int maxPageCount, int maxRetryCount,
-            HttpAsyncClientSupplier httpClientSupplier, String userAgent, Path cacheDirectory) {
+    NvdCveClient(String apiKey, String endpoint, long delay, int maxPageCount, int maxRetryCount,
+            HttpAsyncClientSupplier httpClientSupplier, String userAgent, Path cacheDirectory, int requestsPerMinute) {
         this.apiKey = apiKey;
         this.userAgent = userAgent;
         if (endpoint == null) {
@@ -219,35 +225,19 @@ public class NvdCveClient implements PagedDataSource<DefCveItem> {
         } else {
             this.endpoint = endpoint;
         }
-        if (threadCount <= 0) {
-            threadCount = 1;
-        }
         this.maxPageCount = maxPageCount;
         // configure the rate limit slightly higher than the published limits:
         // https://nvd.nist.gov/developers/start-here (see Rate Limits)
-
         RateMeter meter;
-        if (apiKey == null) {
-            // if (threadCount > 1) {
-            // LOG.warn(
-            // "No api key provided; as such the thread count has been reset to 1 instead of the requested {}",
-            // threadCount);
-            // threadCount = 1;
-            // }
-            int asyncCallCount = 5;
-            // if (callsPerThread != null && callsPerThread > 0) {
-            // asyncCallCount = callsPerThread;
-            // }
-            meter = new RateMeter(asyncCallCount, 32500);
+        if (requestsPerMinute > 0) {
+            meter = new RateMeter(requestsPerMinute, 60500);
+        } else if (apiKey == null) {
+            meter = new RateMeter(5, 30500);
         } else {
-            int asyncCallCount = 50;
-            // if (callsPerThread != null && callsPerThread > 0) {
-            // asyncCallCount = callsPerThread;
-            // }
-            meter = new RateMeter(asyncCallCount, 32500);
+            meter = new RateMeter(50, 30500);
         }
         if (delay == 0) {
-            delay = apiKey == null ? 6500 : 600;
+            delay = meter.getQuantity() / meter.getDuration();
         }
         rlClient = new RateLimitedClient(maxRetryCount, delay, meter, httpClientSupplier, cacheDirectory);
         objectMapper = new ObjectMapper();

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/NvdCveClientBuilder.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/NvdCveClientBuilder.java
@@ -72,9 +72,9 @@ public final class NvdCveClientBuilder implements Cloneable {
      */
     private int maxRetryCount = 10;
     /**
-     * The number of requests to make per a rolling 60 seconds.
+     * The number of requests to make per a rolling 30-seconds.
      */
-    private int requestsPerMinute = 0;
+    private int requestsPerThirtySeconds = 0;
     /**
      * The maximum number of pages to retrieve from the NVD API.
      */
@@ -166,13 +166,13 @@ public final class NvdCveClientBuilder implements Cloneable {
     }
 
     /**
-     * Set the number of requests to make in a rolling 60 seconds.
+     * Set the number of requests to make in a rolling 30-seconds.
      *
-     * @param requestsPerMinute the number of requests to make in a rolling 60 seconds.
+     * @param requestsPerThirtySeconds the number of requests to make in a rolling 30-seconds.
      * @return the builder
      */
-    public NvdCveClientBuilder withRequestsPerMinute(int requestsPerMinute) {
-        this.requestsPerMinute = requestsPerMinute;
+    public NvdCveClientBuilder withrequestsPerThirtySeconds(int requestsPerThirtySeconds) {
+        this.requestsPerThirtySeconds = requestsPerThirtySeconds;
         return this;
     }
 
@@ -391,7 +391,7 @@ public final class NvdCveClientBuilder implements Cloneable {
      */
     public NvdCveClient build() {
         NvdCveClient client = new NvdCveClient(apiKey, endpoint, delay, maxPageCount, maxRetryCount, httpClientSupplier,
-                userAgent, cacheDirectory, requestsPerMinute);
+                userAgent, cacheDirectory, requestsPerThirtySeconds);
         if (!filters.isEmpty()) {
             client.setFilters(filters);
         }
@@ -418,7 +418,7 @@ public final class NvdCveClientBuilder implements Cloneable {
         clone.resultsPerPage = this.resultsPerPage;
         clone.delay = this.delay;
         clone.maxRetryCount = this.maxRetryCount;
-        clone.requestsPerMinute = this.requestsPerMinute;
+        clone.requestsPerThirtySeconds = this.requestsPerThirtySeconds;
         clone.maxPageCount = this.maxPageCount;
         clone.userAgent = this.userAgent;
 

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/NvdCveClientBuilder.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/NvdCveClientBuilder.java
@@ -72,9 +72,9 @@ public final class NvdCveClientBuilder implements Cloneable {
      */
     private int maxRetryCount = 10;
     /**
-     * The number of threads to use when calling the NVD API.
+     * The number of requests to make per a rolling 60 seconds.
      */
-    private int threadCount = 1;
+    private int requestsPerMinute = 0;
     /**
      * The maximum number of pages to retrieve from the NVD API.
      */
@@ -166,13 +166,13 @@ public final class NvdCveClientBuilder implements Cloneable {
     }
 
     /**
-     * Set the number of threads to use when calling the NVD API.
+     * Set the number of requests to make in a rolling 60 seconds.
      *
-     * @param count the number of threads to use when calling the NVD API
+     * @param requestsPerMinute the number of requests to make in a rolling 60 seconds.
      * @return the builder
      */
-    public NvdCveClientBuilder withThreadCount(int count) {
-        this.threadCount = count;
+    public NvdCveClientBuilder withRequestsPerMinute(int requestsPerMinute) {
+        this.requestsPerMinute = requestsPerMinute;
         return this;
     }
 
@@ -390,8 +390,8 @@ public final class NvdCveClientBuilder implements Cloneable {
      * @return the NVD CVE API client
      */
     public NvdCveClient build() {
-        NvdCveClient client = new NvdCveClient(apiKey, endpoint, delay, threadCount, maxPageCount, maxRetryCount,
-                httpClientSupplier, userAgent, cacheDirectory);
+        NvdCveClient client = new NvdCveClient(apiKey, endpoint, delay, maxPageCount, maxRetryCount, httpClientSupplier,
+                userAgent, cacheDirectory, requestsPerMinute);
         if (!filters.isEmpty()) {
             client.setFilters(filters);
         }
@@ -418,7 +418,7 @@ public final class NvdCveClientBuilder implements Cloneable {
         clone.resultsPerPage = this.resultsPerPage;
         clone.delay = this.delay;
         clone.maxRetryCount = this.maxRetryCount;
-        clone.threadCount = this.threadCount;
+        clone.requestsPerMinute = this.requestsPerMinute;
         clone.maxPageCount = this.maxPageCount;
         clone.userAgent = this.userAgent;
 

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/RateLimitedCall.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/RateLimitedCall.java
@@ -21,14 +21,12 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 public class RateLimitedCall {
     private final SimpleHttpResponse response;
-    private final int clientIndex;
     private final int startIndex;
 
     @SuppressFBWarnings(value = {"EI_EXPOSE_REP",
             "EI_EXPOSE_REP2"}, justification = "I prefer to suppress these FindBugs warnings")
-    public RateLimitedCall(SimpleHttpResponse response, int clientIndex, int startIndex) {
+    public RateLimitedCall(SimpleHttpResponse response, int startIndex) {
         this.response = response;
-        this.clientIndex = clientIndex;
         this.startIndex = startIndex;
     }
 
@@ -36,10 +34,6 @@ public class RateLimitedCall {
             "EI_EXPOSE_REP2"}, justification = "I prefer to suppress these FindBugs warnings")
     public SimpleHttpResponse getResponse() {
         return response;
-    }
-
-    public int getClientIndex() {
-        return clientIndex;
     }
 
     public int getStartIndex() {

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/RateLimitedClient.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/RateLimitedClient.java
@@ -309,7 +309,8 @@ class RateLimitedClient implements AutoCloseable {
                 throw (ExecutionException) e;
             }
             throw new NvdApiException(e);
-        } finally {
+        }
+        finally {
             if (t != null) {
                 try {
                     t.close();

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/RateLimitedClient.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/RateLimitedClient.java
@@ -250,8 +250,8 @@ class RateLimitedClient implements AutoCloseable {
      * @param request the request
      * @return the future response
      */
-    Future<RateLimitedCall> execute(SimpleHttpRequest request, int clientIndex, int startIndex) {
-        return executor.submit(() -> delayedExecute(request, clientIndex, startIndex));
+    Future<RateLimitedCall> execute(SimpleHttpRequest request, int startIndex) {
+        return executor.submit(() -> delayedExecute(request, startIndex));
     }
 
     /**
@@ -262,7 +262,7 @@ class RateLimitedClient implements AutoCloseable {
      * @throws ExecutionException thrown if there is an exception
      * @throws InterruptedException thrown if interrupted
      */
-    private RateLimitedCall delayedExecute(SimpleHttpRequest request, int clientIndex, int startIndex)
+    private RateLimitedCall delayedExecute(SimpleHttpRequest request, int startIndex)
             throws ExecutionException, InterruptedException {
         request.addHeader("Cache-Control", "max-age=72000"); // 20 hours in seconds
         if (cacheStorage != null) {
@@ -273,7 +273,7 @@ class RateLimitedClient implements AutoCloseable {
                 if (entry != null) {
                     // we know it is in the cache so just make the call without additional rate limit checks
                     Future<SimpleHttpResponse> f = client.execute(request, new SimpleFutureResponse());
-                    return new RateLimitedCall(f.get(), clientIndex, startIndex);
+                    return new RateLimitedCall(f.get(), startIndex);
                 }
             } catch (URISyntaxException | ResourceIOException e) {
                 // do nothing and fall through to the next step
@@ -289,7 +289,9 @@ class RateLimitedClient implements AutoCloseable {
                 Thread.sleep(wait);
             }
         }
-        try (RateMeter.Ticket t = meter.getTicket()) {
+        RateMeter.Ticket t = null;
+        try {
+            t = meter.getTicket();
             if (LOG.isDebugEnabled()) {
                 LocalTime time = LocalTime.now();
                 DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm:ss");
@@ -299,7 +301,7 @@ class RateLimitedClient implements AutoCloseable {
             }
             Future<SimpleHttpResponse> f = client.execute(request, new SimpleFutureResponse());
             lastRequest = ZonedDateTime.now().toInstant().toEpochMilli();
-            return new RateLimitedCall(f.get(), clientIndex, startIndex);
+            return new RateLimitedCall(f.get(), startIndex);
         } catch (Exception e) {
             if (e instanceof InterruptedException) {
                 throw (InterruptedException) e;
@@ -307,6 +309,14 @@ class RateLimitedClient implements AutoCloseable {
                 throw (ExecutionException) e;
             }
             throw new NvdApiException(e);
+        } finally {
+            if (t != null) {
+                try {
+                    t.close();
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }
         }
     }
 

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/RateLimitedClient.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/RateLimitedClient.java
@@ -170,18 +170,23 @@ class RateLimitedClient implements AutoCloseable {
     @SuppressFBWarnings("CT_CONSTRUCTOR_THROW")
     RateLimitedClient(int maxRetries, long minimumDelay, int requestsPerThirtySeconds,
             HttpAsyncClientSupplier httpClientSupplier, Path cachePath, boolean hasApiKey) {
-        // configure the rate limit slightly higher than the published limits:
-        // https://nvd.nist.gov/developers/start-here (see Rate Limits)
-        if (requestsPerThirtySeconds > 0) {
-            meter = new RateMeter(requestsPerThirtySeconds, 60500);
-        } else if (hasApiKey) {
-            meter = new RateMeter(50, 30500);
-        } else {
-            meter = new RateMeter(5, 30500);
+        int rate = 5;
+        if (hasApiKey) {
+            rate = 50;
         }
-        delay = minimumDelay > 0 ? minimumDelay
-                : Math.max(1, (long) Math.ceil((double) meter.getQuantity() / meter.getDuration()));
+        if (requestsPerThirtySeconds > 0 && requestsPerThirtySeconds < rate) {
+            rate = requestsPerThirtySeconds;
+        }
+        // configure the rate limit slightly higher than the published limits. 32500 instead of 30000.
+        // https://nvd.nist.gov/developers/start-here (see Rate Limits)
+        meter = new RateMeter(rate, 32500);
+
+        delay = Math.max(1, (long) Math.ceil((double) meter.getQuantity() / meter.getDuration()));
+        if (minimumDelay > 0 && minimumDelay > delay) {
+            delay = minimumDelay;
+        }
         if (LOG.isDebugEnabled()) {
+            LOG.debug("rate limited calls: {}/30s", rate);
             LOG.debug("rate limited call delay: {}", delay);
         }
         if (httpClientSupplier == null) {

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/RateLimitedClient.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/RateLimitedClient.java
@@ -313,7 +313,8 @@ class RateLimitedClient implements AutoCloseable {
                 Thread.sleep(wait);
             }
         }
-        try (RateMeter.Ticket t = meter.getTicket()) {
+        try {
+            meter.checkRateLimit();
             if (LOG.isDebugEnabled()) {
                 LocalTime time = LocalTime.now();
                 DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm:ss");

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/RateLimitedClient.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/RateLimitedClient.java
@@ -48,10 +48,17 @@ import java.time.Duration;
 import java.time.LocalTime;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Objects;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.PriorityBlockingQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Rate limited client for use with a rate limited API. The client contains two mechanisms to control the rate:
@@ -80,7 +87,8 @@ class RateLimitedClient implements AutoCloseable {
     /**
      * Executor service for async implementation.
      */
-    private final ExecutorService executor = Executors.newSingleThreadExecutor();
+    private final ExecutorService executor = new PrioritizedExecutor(1, 1, 0L, TimeUnit.MILLISECONDS,
+            Executors.defaultThreadFactory());
     /**
      * The epoch time of the last request.
      */
@@ -262,7 +270,7 @@ class RateLimitedClient implements AutoCloseable {
      * @return the future response
      */
     Future<RateLimitedCall> execute(SimpleHttpRequest request, int startIndex) {
-        return executor.submit(() -> delayedExecute(request, startIndex));
+        return executor.submit(new PrioritizedCallable<>(() -> delayedExecute(request, startIndex), startIndex));
     }
 
     /**
@@ -342,6 +350,86 @@ class RateLimitedClient implements AutoCloseable {
         @Override
         public void cancelled() {
             // do nothing
+        }
+    }
+
+    private static class PrioritizedExecutor extends ThreadPoolExecutor {
+
+        public PrioritizedExecutor(int corePoolSize, int maximumPoolSize, long keepAliveTime, TimeUnit unit,
+                ThreadFactory threadFactory) {
+            super(corePoolSize, maximumPoolSize, keepAliveTime, unit, new PriorityBlockingQueue<>(), threadFactory);
+        }
+
+        @Override
+        public Future<?> submit(Runnable task) {
+            if (task instanceof PrioritizedFutureTask) {
+                execute(task);
+                return (Future<?>) task;
+            } else {
+                return super.submit(task);
+            }
+        }
+
+        @Override
+        public <T> Future<T> submit(Callable<T> task) {
+            if (task instanceof PrioritizedCallable) {
+                PrioritizedCallable<T> prioritizedTask = (PrioritizedCallable<T>) task;
+                PrioritizedFutureTask<T> futureTask = new PrioritizedFutureTask<>(prioritizedTask,
+                        prioritizedTask.getStartIndex());
+                execute(futureTask);
+                return futureTask;
+            } else {
+                return super.submit(task);
+            }
+        }
+    }
+
+    private static class PrioritizedCallable<T> implements Callable<T> {
+        private final Callable<T> task;
+        private final int startIndex;
+
+        public PrioritizedCallable(Callable<T> task, int startIndex) {
+            this.task = task;
+            this.startIndex = startIndex;
+        }
+
+        @Override
+        public T call() throws Exception {
+            return task.call();
+        }
+
+        public int getStartIndex() {
+            return startIndex;
+        }
+    }
+
+    private static class PrioritizedFutureTask<T> extends FutureTask<T>
+            implements Comparable<PrioritizedFutureTask<T>> {
+        private final int startIndex;
+
+        public PrioritizedFutureTask(Callable<T> callable, int startIndex) {
+            super(callable);
+            this.startIndex = startIndex;
+        }
+
+        @Override
+        public int compareTo(PrioritizedFutureTask<T> other) {
+            return Integer.compare(this.startIndex, other.startIndex);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o)
+                return true;
+            if (o == null || getClass() != o.getClass())
+                return false;
+            PrioritizedFutureTask<?> that = (PrioritizedFutureTask<?>) o;
+            return startIndex == that.startIndex;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(startIndex);
         }
     }
 }

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/RateLimitedClient.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/RateLimitedClient.java
@@ -171,7 +171,8 @@ class RateLimitedClient implements AutoCloseable {
         } else {
             meter = new RateMeter(5, 30500);
         }
-        delay = minimumDelay > 0 ? minimumDelay : meter.getQuantity() / meter.getDuration();
+        delay = minimumDelay > 0 ? minimumDelay
+                : Math.max(1, (long) Math.ceil((double) meter.getQuantity() / meter.getDuration()));
         if (LOG.isDebugEnabled()) {
             LOG.debug("rate limited call delay: {}", delay);
         }

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/RateLimitedClient.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/RateLimitedClient.java
@@ -72,7 +72,7 @@ class RateLimitedClient implements AutoCloseable {
     /**
      * Reference to the logger.
      */
-    private final static Logger LOG = LoggerFactory.getLogger(SimpleFutureResponse.class);
+    private final static Logger LOG = LoggerFactory.getLogger(RateLimitedClient.class);
     /**
      * The underlying Async Client.
      */
@@ -97,10 +97,27 @@ class RateLimitedClient implements AutoCloseable {
     ForcedDiskCacheStorage cacheStorage = null;
 
     /**
-     * Construct a rate limited client without a delay or limiters.
+     * Construct a rate limited client without the default minimum delay and 5 requests over a 30-second window.
      */
     RateLimitedClient() {
-        this(0, 0, 0);
+        this(0, 0, false);
+    }
+
+    /**
+     * Construct a rate limited client without the default minimum delay and 5 requests over a 30-second window without
+     * an API key or 50 requests over a 30-second window with an API Key..
+     */
+    RateLimitedClient(boolean hasApiKey) {
+        this(0, 0, hasApiKey);
+    }
+
+    /**
+     * Construct a rate limited client.
+     *
+     * @param requestsPerThirtySeconds the number of requests allowed over a rolling 30-second window.
+     */
+    RateLimitedClient(int requestsPerThirtySeconds) {
+        this(0, requestsPerThirtySeconds, false);
     }
 
     /**
@@ -108,27 +125,11 @@ class RateLimitedClient implements AutoCloseable {
      * configure 5 requests are allowed over a 30-second rolling window and we will delay at least 4 seconds between
      * calls to help more evenly distribute the calls across the request window.
      *
-     * @param minimumDelay the number of milliseconds to wait between API calls
-     * @param requestsCount the number of requests allowed during the rolling request window timespan
-     * @param requestWindowMilliseconds the rolling request window size in milliseconds
+     * @param delay the number of milliseconds to wait between API calls
+     * @param requestsPerThirtySeconds the number of requests allowed over a rolling 30-second window
      */
-    RateLimitedClient(long minimumDelay, int requestsCount, long requestWindowMilliseconds) {
-        this(minimumDelay,
-                (requestsCount > 0 && requestWindowMilliseconds > 0)
-                        ? new RateMeter(requestsCount, requestWindowMilliseconds)
-                        : new RateMeter(100, 5));
-    }
-
-    /**
-     * Construct a rate limited client with a given delay and request window configuration. This allows callers to
-     * configure 5 requests are allowed over a 30-second rolling window and we will delay at least 4 seconds between
-     * calls to help more evenly distribute the calls across the request window.
-     *
-     * @param minimumDelay the number of milliseconds to wait between API calls
-     * @param meter the rate meter to limit the request rate
-     */
-    RateLimitedClient(long minimumDelay, RateMeter meter) {
-        this(10, minimumDelay, meter, null);
+    RateLimitedClient(long delay, int requestsPerThirtySeconds, boolean hasApiKey) {
+        this(10, delay, requestsPerThirtySeconds, null, hasApiKey);
     }
 
     /**
@@ -138,12 +139,13 @@ class RateLimitedClient implements AutoCloseable {
      *
      * @param maxRetries the maximum number of retry attemps
      * @param minimumDelay the number of milliseconds to wait between API calls
-     * @param meter the rate meter to limit the request rate
+     * @param requestsPerThirtySeconds the number of requests allowed over a rolling 30-second window
      * @param httpClientSupplier supplier for custom HTTP clients; if {@code null} a default client will be used
      */
     @SuppressFBWarnings("CT_CONSTRUCTOR_THROW")
-    RateLimitedClient(int maxRetries, long minimumDelay, RateMeter meter, HttpAsyncClientSupplier httpClientSupplier) {
-        this(maxRetries, minimumDelay, meter, httpClientSupplier, null);
+    RateLimitedClient(int maxRetries, long minimumDelay, int requestsPerThirtySeconds,
+            HttpAsyncClientSupplier httpClientSupplier, boolean hasApiKey) {
+        this(maxRetries, minimumDelay, requestsPerThirtySeconds, httpClientSupplier, null, hasApiKey);
     }
 
     /**
@@ -153,15 +155,23 @@ class RateLimitedClient implements AutoCloseable {
      *
      * @param maxRetries the maximum number of retry attemps
      * @param minimumDelay the number of milliseconds to wait between API calls
-     * @param meter the rate meter to limit the request rate
+     * @param requestsPerThirtySeconds the number of requests allowed over a rolling 30-second window
      * @param httpClientSupplier supplier for custom HTTP clients; if {@code null} a default client will be used
      * @param cachePath the path to the cache directory, can be null
      */
     @SuppressFBWarnings("CT_CONSTRUCTOR_THROW")
-    RateLimitedClient(int maxRetries, long minimumDelay, RateMeter meter, HttpAsyncClientSupplier httpClientSupplier,
-            Path cachePath) {
-        this.meter = meter;
-        this.delay = minimumDelay;
+    RateLimitedClient(int maxRetries, long minimumDelay, int requestsPerThirtySeconds,
+            HttpAsyncClientSupplier httpClientSupplier, Path cachePath, boolean hasApiKey) {
+        // configure the rate limit slightly higher than the published limits:
+        // https://nvd.nist.gov/developers/start-here (see Rate Limits)
+        if (requestsPerThirtySeconds > 0) {
+            meter = new RateMeter(requestsPerThirtySeconds, 60500);
+        } else if (hasApiKey) {
+            meter = new RateMeter(50, 30500);
+        } else {
+            meter = new RateMeter(5, 30500);
+        }
+        delay = minimumDelay > 0 ? minimumDelay : meter.getQuantity() / meter.getDuration();
         if (LOG.isDebugEnabled()) {
             LOG.debug("rate limited call delay: {}", delay);
         }
@@ -266,7 +276,7 @@ class RateLimitedClient implements AutoCloseable {
             throws ExecutionException, InterruptedException {
         request.addHeader("Cache-Control", "max-age=72000"); // 20 hours in seconds
         if (cacheStorage != null) {
-            HttpCacheEntry entry = null;
+            HttpCacheEntry entry;
             try {
                 String key = CacheKeyGenerator.INSTANCE.generateKey(request.getUri());
                 entry = cacheStorage.getEntry(key);
@@ -289,9 +299,7 @@ class RateLimitedClient implements AutoCloseable {
                 Thread.sleep(wait);
             }
         }
-        RateMeter.Ticket t = null;
-        try {
-            t = meter.getTicket();
+        try (RateMeter.Ticket t = meter.getTicket()) {
             if (LOG.isDebugEnabled()) {
                 LocalTime time = LocalTime.now();
                 DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm:ss");
@@ -309,15 +317,6 @@ class RateLimitedClient implements AutoCloseable {
                 throw (ExecutionException) e;
             }
             throw new NvdApiException(e);
-        }
-        finally {
-            if (t != null) {
-                try {
-                    t.close();
-                } catch (Exception e) {
-                    throw new RuntimeException(e);
-                }
-            }
         }
     }
 

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/RateMeter.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/RateMeter.java
@@ -19,41 +19,44 @@ package io.github.jeremylong.openvulnerability.client.nvd;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.time.LocalTime;
-import java.time.format.DateTimeFormatter;
-import java.util.Objects;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.DelayQueue;
-import java.util.concurrent.Delayed;
-import java.util.concurrent.TimeUnit;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
- * A rate limiting meter that works by granting tickets. The tickets are closable - do not leak tickets. The tickets are
- * auto-closable so should be granted in a try with resources:
- *
- * <pre>
- * int duration = 30000;
- * int queueSize = 5;
- * RateMeter instance = new RateMeter(queueSize, duration);
- * try (RateMeter.Ticket t = instance.getTicket()) {
- *     // do something
- * }
- * </pre>
+ * A rate meter to limit the number of calls over a rolling time window.
  */
 public class RateMeter {
     /**
      * Reference to the logger.
      */
     private static final Logger LOG = LoggerFactory.getLogger(RateMeter.class);
-    private final BlockingQueue<Ticket> queue = new DelayQueue<>();
-    private int quantity;
-    private long durationMilliseconds;
 
     /**
-     * Creates a new rate meter to limit how quickly an operation can take place.
+     * The maximum number of tickets allowed in the rolling window.
+     */
+    private final int quantity;
+
+    /**
+     * The duration of the rolling window in milliseconds.
+     */
+    private final long durationMilliseconds;
+
+    /**
+     * Queue to track timestamps of issued tickets.
+     */
+    private final Queue<Long> ticketTimestamps = new LinkedList<>();
+
+    /**
+     * Lock to ensure thread safety.
+     */
+    private final ReentrantLock lock = new ReentrantLock();
+
+    /**
+     * Constructs a new rate meter with the specified quantity and duration.
      *
-     * @param quantity the number of tickets available
-     * @param durationMilliseconds the duration of a ticket in milliseconds
+     * @param quantity the maximum number of tickets allowed in the rolling window
+     * @param durationMilliseconds the duration of the rolling window in milliseconds
      */
     public RateMeter(int quantity, long durationMilliseconds) {
         this.quantity = quantity;
@@ -61,97 +64,99 @@ public class RateMeter {
     }
 
     /**
-     * Grants a ticket to proceed given the rate limit. Tickets are closable - do not leak tickets; remember to close
-     * them.
+     * Gets a ticket from the rate meter, blocking if necessary until a ticket becomes available.
      *
-     * @return a ticket
-     * @throws InterruptedException thrown if interrupted
+     * @return a ticket that must be closed when the operation is complete
+     * @throws InterruptedException if the thread is interrupted while waiting
      */
-    public synchronized Ticket getTicket() throws InterruptedException {
-        if (queue.size() >= quantity) {
-            Ticket ticket = queue.take();
-            if (LOG.isDebugEnabled()) {
-                final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm:ss");
-                final LocalTime time = LocalTime.now();
-                LOG.debug("Ticket taken At: {}; count: {}", time.format(formatter), queue.size() + 1);
+    public Ticket getTicket() throws InterruptedException {
+        lock.lock();
+        try {
+            long now = System.currentTimeMillis();
+            // Remove expired timestamps from the queue
+            while (!ticketTimestamps.isEmpty() && ticketTimestamps.peek() < now - durationMilliseconds) {
+                ticketTimestamps.poll();
             }
-            return ticket;
+
+            // If we've reached the limit, calculate wait time
+            if (ticketTimestamps.size() >= quantity) {
+                long oldestTimestamp = ticketTimestamps.peek();
+                long waitTime = oldestTimestamp + durationMilliseconds - now;
+
+                if (waitTime > 0) {
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("Rate limit reached. Waiting for {}ms before next request", waitTime);
+                    }
+                    // Release the lock while waiting
+                    lock.unlock();
+                    try {
+                        Thread.sleep(waitTime);
+                    }
+                    finally {
+                        // Reacquire the lock
+                        lock.lock();
+                    }
+
+                    // After waiting, we need to recalculate
+                    now = System.currentTimeMillis();
+                    // Remove expired timestamps again
+                    while (!ticketTimestamps.isEmpty() && ticketTimestamps.peek() < now - durationMilliseconds) {
+                        ticketTimestamps.poll();
+                    }
+                }
+            }
+
+            // Add the current timestamp to the queue
+            ticketTimestamps.add(now);
+
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Ticket issued. Current usage: {}/{} in the last {}ms", ticketTimestamps.size(), quantity,
+                        durationMilliseconds);
+            }
+
+            return new Ticket();
         }
-        if (LOG.isDebugEnabled()) {
-            final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm:ss");
-            final LocalTime time = LocalTime.now();
-            LOG.debug("Ticket taken At: {}; count: {}; by {}", time.format(formatter), queue.size() + 1,
-                    Thread.currentThread().getId());
+        finally {
+            lock.unlock();
         }
-        return new Ticket(this);
     }
 
-    synchronized void replaceTicket() throws InterruptedException {
-        if (queue.size() < quantity) {
-            queue.put(new Ticket(this));
-            if (LOG.isDebugEnabled()) {
-                final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm:ss");
-                final LocalTime time = LocalTime.now();
-                LOG.debug("Ticket returned At: {}; count: {}; by {}", time.format(formatter), queue.size() + 1,
-                        Thread.currentThread().getId());
+    /**
+     * A ticket representing permission to make an API call. The ticket should be closed after the API call is complete.
+     */
+    public static class Ticket implements AutoCloseable {
+        private static final Logger LOG = LoggerFactory.getLogger(Ticket.class);
+        private final long timestamp;
+        private boolean closed = false;
+
+        private Ticket() {
+            this.timestamp = System.currentTimeMillis();
+        }
+
+        @Override
+        public void close() {
+            if (!closed) {
+                closed = true;
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Ticket closed after {}ms", System.currentTimeMillis() - timestamp);
+                }
             }
         }
     }
 
+    /**
+     * Returns the quantity of tickets allowed in the rolling window.
+     * @return the quantity of tickets allowed in the rolling window.
+     */
     public int getQuantity() {
-        return quantity;
+        return this.quantity;
     }
 
-    public void setQuantity(int quantity) {
-        this.quantity = quantity;
-    }
-
-    public long getDurationMilliseconds() {
-        return durationMilliseconds;
-    }
-
-    public void setDurationMilliseconds(long durationMilliseconds) {
-        this.durationMilliseconds = durationMilliseconds;
-    }
-
-    public static class Ticket implements Delayed, AutoCloseable {
-        private final RateMeter meter;
-        private final long startTime;
-
-        Ticket(RateMeter meter) {
-            this.meter = meter;
-            this.startTime = System.currentTimeMillis() + meter.getDurationMilliseconds();
-        }
-
-        @Override
-        public long getDelay(TimeUnit unit) {
-            long diff = startTime - System.currentTimeMillis();
-            return unit.convert(diff, TimeUnit.MILLISECONDS);
-        }
-
-        @Override
-        public int compareTo(Delayed o) {
-            return (int) (this.startTime - ((Ticket) o).startTime);
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o)
-                return true;
-            if (o == null || getClass() != o.getClass())
-                return false;
-            Ticket ticket = (Ticket) o;
-            return startTime == ticket.startTime;
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(startTime);
-        }
-
-        @Override
-        public void close() throws Exception {
-            meter.replaceTicket();
-        }
+    /**
+     * Returns the duration of the rolling window in milliseconds.
+     * @return the duration of the rolling window in milliseconds.
+     */
+    public long getDuration() {
+        return this.durationMilliseconds;
     }
 }

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/RateMeter.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/RateMeter.java
@@ -33,7 +33,7 @@ public class RateMeter {
     private static final Logger LOG = LoggerFactory.getLogger(RateMeter.class);
 
     /**
-     * The maximum number of tickets allowed in the rolling window.
+     * The maximum number of operations allowed in the rolling window.
      */
     private final int quantity;
 
@@ -43,9 +43,9 @@ public class RateMeter {
     private final long durationMilliseconds;
 
     /**
-     * Queue to track timestamps of issued tickets.
+     * Queue to track timestamps of allowed operations.
      */
-    private final Queue<Long> ticketTimestamps = new LinkedList<>();
+    private final Queue<Long> timestamps = new LinkedList<>();
 
     /**
      * Lock to ensure thread safety.
@@ -55,7 +55,7 @@ public class RateMeter {
     /**
      * Constructs a new rate meter with the specified quantity and duration.
      *
-     * @param quantity the maximum number of tickets allowed in the rolling window
+     * @param quantity the maximum number of operations allowed in the rolling window
      * @param durationMilliseconds the duration of the rolling window in milliseconds
      */
     public RateMeter(int quantity, long durationMilliseconds) {
@@ -64,23 +64,22 @@ public class RateMeter {
     }
 
     /**
-     * Gets a ticket from the rate meter, blocking if necessary until a ticket becomes available.
+     * Checks if the rate limit has been reached and waits if necessary.
      *
-     * @return a ticket that must be closed when the operation is complete
      * @throws InterruptedException if the thread is interrupted while waiting
      */
-    public Ticket getTicket() throws InterruptedException {
+    public void checkRateLimit() throws InterruptedException {
         lock.lock();
         try {
             long now = System.currentTimeMillis();
             // Remove expired timestamps from the queue
-            while (!ticketTimestamps.isEmpty() && ticketTimestamps.peek() < now - durationMilliseconds) {
-                ticketTimestamps.poll();
+            while (!timestamps.isEmpty() && timestamps.peek() < now - durationMilliseconds) {
+                timestamps.poll();
             }
 
             // If we've reached the limit, calculate wait time
-            if (ticketTimestamps.size() >= quantity) {
-                long oldestTimestamp = ticketTimestamps.peek();
+            if (timestamps.size() >= quantity) {
+                long oldestTimestamp = timestamps.peek();
                 long waitTime = oldestTimestamp + durationMilliseconds - now;
 
                 if (waitTime > 0) {
@@ -100,21 +99,19 @@ public class RateMeter {
                     // After waiting, we need to recalculate
                     now = System.currentTimeMillis();
                     // Remove expired timestamps again
-                    while (!ticketTimestamps.isEmpty() && ticketTimestamps.peek() < now - durationMilliseconds) {
-                        ticketTimestamps.poll();
+                    while (!timestamps.isEmpty() && timestamps.peek() < now - durationMilliseconds) {
+                        timestamps.poll();
                     }
                 }
             }
 
             // Add the current timestamp to the queue
-            ticketTimestamps.add(now);
+            timestamps.add(now);
 
             if (LOG.isDebugEnabled()) {
-                LOG.debug("Ticket issued. Current usage: {}/{} in the last {}ms", ticketTimestamps.size(), quantity,
+                LOG.debug("Rate limit usage: {}/{} in the last {}ms", timestamps.size(), quantity,
                         durationMilliseconds);
             }
-
-            return new Ticket();
         }
         finally {
             lock.unlock();
@@ -122,31 +119,8 @@ public class RateMeter {
     }
 
     /**
-     * A ticket representing permission to make an API call. The ticket should be closed after the API call is complete.
-     */
-    public static class Ticket implements AutoCloseable {
-        private static final Logger LOG = LoggerFactory.getLogger(Ticket.class);
-        private final long timestamp;
-        private boolean closed = false;
-
-        private Ticket() {
-            this.timestamp = System.currentTimeMillis();
-        }
-
-        @Override
-        public void close() {
-            if (!closed) {
-                closed = true;
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("Ticket closed after {}ms", System.currentTimeMillis() - timestamp);
-                }
-            }
-        }
-    }
-
-    /**
-     * Returns the quantity of tickets allowed in the rolling window.
-     * @return the quantity of tickets allowed in the rolling window.
+     * Returns the quantity of operations allowed in the rolling window.
+     * @return the quantity of operations allowed in the rolling window.
      */
     public int getQuantity() {
         return this.quantity;

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/RateMeter.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/RateMeter.java
@@ -45,7 +45,7 @@ public class RateMeter {
     /**
      * Queue to track timestamps of allowed operations.
      */
-    private final Queue<Long> timestamps = new LinkedList<>();
+    private final Queue<Long> ticketTimestamps = new LinkedList<>();
 
     /**
      * Lock to ensure thread safety.
@@ -71,47 +71,16 @@ public class RateMeter {
     public void checkRateLimit() throws InterruptedException {
         lock.lock();
         try {
-            long now = System.currentTimeMillis();
-            // Remove expired timestamps from the queue
-            while (!timestamps.isEmpty() && timestamps.peek() < now - durationMilliseconds) {
-                timestamps.poll();
-            }
+            long waitTime = calculateWaitTime();
 
-            // If we've reached the limit, calculate wait time
-            if (timestamps.size() >= quantity) {
-                long oldestTimestamp = timestamps.peek();
-                long waitTime = oldestTimestamp + durationMilliseconds - now;
-
-                if (waitTime > 0) {
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug("Rate limit reached. Waiting for {}ms before next request", waitTime);
-                    }
-                    // Release the lock while waiting
-                    lock.unlock();
-                    try {
-                        Thread.sleep(waitTime);
-                    }
-                    finally {
-                        // Reacquire the lock
-                        lock.lock();
-                    }
-
-                    // After waiting, we need to recalculate
-                    now = System.currentTimeMillis();
-                    // Remove expired timestamps again
-                    while (!timestamps.isEmpty() && timestamps.peek() < now - durationMilliseconds) {
-                        timestamps.poll();
-                    }
+            if (waitTime > 0) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Rate limit reached. Waiting for {}ms.", waitTime);
                 }
+                Thread.sleep(waitTime);
             }
 
-            // Add the current timestamp to the queue
-            timestamps.add(now);
-
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Rate limit usage: {}/{} in the last {}ms", timestamps.size(), quantity,
-                        durationMilliseconds);
-            }
+            recordRequest();
         }
         finally {
             lock.unlock();
@@ -119,7 +88,48 @@ public class RateMeter {
     }
 
     /**
+     * Calculates the wait time needed before the next request can be made.
+     *
+     * @return the wait time in milliseconds, or 0 if no wait is needed
+     */
+    private long calculateWaitTime() {
+        long now = System.currentTimeMillis();
+        // Remove expired timestamps from the queue
+        while (!ticketTimestamps.isEmpty() && ticketTimestamps.peek() < now - durationMilliseconds) {
+            ticketTimestamps.poll();
+        }
+
+        // If we've reached the limit, calculate wait time
+        if (ticketTimestamps.size() >= quantity) {
+            long oldestTimestamp = ticketTimestamps.peek();
+            long waitTime = oldestTimestamp + durationMilliseconds - now;
+            return Math.max(waitTime, 0);
+        }
+        return 0;
+    }
+
+    /**
+     * Records a new request in the rate meter.
+     */
+    private void recordRequest() {
+        long now = System.currentTimeMillis();
+        // Clean up expired timestamps again (in case time passed during waiting)
+        while (!ticketTimestamps.isEmpty() && ticketTimestamps.peek() < now - durationMilliseconds) {
+            ticketTimestamps.poll();
+        }
+
+        // Add the current timestamp to the queue
+        ticketTimestamps.add(now);
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Rate limit usage: {}/{} in the last {}ms", ticketTimestamps.size(), quantity,
+                    durationMilliseconds);
+        }
+    }
+
+    /**
      * Returns the quantity of operations allowed in the rolling window.
+     *
      * @return the quantity of operations allowed in the rolling window.
      */
     public int getQuantity() {
@@ -128,6 +138,7 @@ public class RateMeter {
 
     /**
      * Returns the duration of the rolling window in milliseconds.
+     * 
      * @return the duration of the rolling window in milliseconds.
      */
     public long getDuration() {

--- a/open-vulnerability-clients/src/test/java/io/github/jeremylong/openvulnerability/client/nvd/RateMeterTest.java
+++ b/open-vulnerability-clients/src/test/java/io/github/jeremylong/openvulnerability/client/nvd/RateMeterTest.java
@@ -29,8 +29,8 @@ class RateMeterTest {
         int queueSize = 2;
         RateMeter instance = new RateMeter(queueSize, durationLimit);
         long startTime = System.currentTimeMillis();
-        instance.getTicket().close();
-        instance.getTicket().close();
+        instance.checkRateLimit();
+        instance.checkRateLimit();
         long endTime = System.currentTimeMillis();
         long duration = endTime - startTime;
         assertTrue(duration < durationLimit, "duration: " + duration);
@@ -38,9 +38,9 @@ class RateMeterTest {
         // ensure requesting more than the quantity we are delayed
         instance = new RateMeter(queueSize, durationLimit);
         startTime = System.currentTimeMillis();
-        instance.getTicket().close();
-        instance.getTicket().close();
-        instance.getTicket().close();
+        instance.checkRateLimit();
+        instance.checkRateLimit();
+        instance.checkRateLimit();
         endTime = System.currentTimeMillis();
         duration = endTime - startTime;
         assertTrue(duration >= durationLimit, "duration: " + duration);


### PR DESCRIPTION
BREAKING CHANGE: Removes threadCount and reworks how the rate meter operates.