### PR TITLE
fix: avoid NPE for response logging in NvdCveClient

### DIFF
--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/NvdCveClient.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/NvdCveClient.java
@@ -414,7 +414,11 @@ public class NvdCveClient implements PagedDataSource<DefCveItem> {
                             msg = header.getValue();
                         }
                     }
-                    LOG.debug("Response: {}", new String(response.getBodyBytes(), StandardCharsets.UTF_8));
+                    
+                    byte[] bodyBytes = response.getBodyBytes();
+                    String responseBody = bodyBytes == null ? null : new String(bodyBytes, StandardCharsets.UTF_8);
+                    LOG.debug("Response: {}", responseBody);
+
                     if (msg != null) {
                         msg = msg.trim();
                         if (msg.contains("Invalid apiKey")) {


### PR DESCRIPTION
When an invalid API key is used, the NVD API returns a `404 Not Found` with an empty body. 
Currently, this leads to a `NullPointerException` (NPE), obscuring the real issue of an invalid API key. 
This exception occurs both when debug mode is enabled and disabled.

Using an invalid NVD API key results in:
- **Response:** `404 Not Found` with empty body.
- **Error:** NPE in the dependency-check project, hiding the invalid API key message, regardless of debug settings.

**Example Stacktrace from OWASP Dependency Check:**
```plaintext
[DEBUG] requesting URI: https://services.nvd.nist.gov/rest/json/cves/2.0?resultsPerPage=1000&startIndex=0
[DEBUG] Ticket taken At: [REDACTED]; count: 1; by [REDACTED]
[DEBUG] Requested At: [REDACTED]; URI: /rest/json/cves/2.0?resultsPerPage=1000&startIndex=0
[DEBUG] Ticket returned At: [REDACTED]; count: 2; by [REDACTED]
[DEBUG] Status Code: 404
[DEBUG] Reason: Not Found
[DEBUG] Response Headers:
[DEBUG] Key : date ,Value : [REDACTED]
[DEBUG] Key : content-length ,Value : 0
[DEBUG] Key : message ,Value : Invalid apiKey.
...
[ERROR] Error updating the NVD Data
org.owasp.dependencycheck.data.update.exception.UpdateException: Error updating the NVD Data
...
Caused by: java.lang.NullPointerException: Cannot read the array length because "bytes" is null
    at java.lang.String.<init> (String.java:1387)
    at io.github.jeremylong.openvulnerability.client.nvd.NvdCveClient._next (NvdCveClient.java:418)
    at io.github.jeremylong.openvulnerability.client.nvd.NvdCveClient.next (NvdCveClient.java:357)
```