### PR TITLE
Remove deprecated cvss field

### DIFF
--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/SecurityAdvisory.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/SecurityAdvisory.java
@@ -30,7 +30,7 @@ import java.util.Objects;
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonPropertyOrder({"databaseId", "description", "ghsaId", "id", "identifiers", "notificationsPermalink", "origin",
         "permalink", "publishedAt", "references", "severity", "summary", "updatedAt", "vulnerabilities",
-        "classification", "cvss", "cvssSeverities", "cwes", "withdrawnAt"})
+        "classification", "cvssSeverities", "cwes", "withdrawnAt"})
 public class SecurityAdvisory implements Serializable {
 
     /**
@@ -85,13 +85,6 @@ public class SecurityAdvisory implements Serializable {
 
     @JsonProperty("classification")
     private String classification;
-
-    // https://docs.github.com/en/graphql/overview/breaking-changes#changes-scheduled-for-2025-10-01
-    // cvss will be removed at 2025-10-01.
-    // New cvssSeverities field will now contain both cvssV3 and cvssV4 properties.
-    @Deprecated(forRemoval = true)
-    @JsonProperty("cvss")
-    private CVSS cvss;
 
     @JsonProperty("cvssSeverities")
     private CVSSSeverities cvssSeverities;
@@ -246,16 +239,6 @@ public class SecurityAdvisory implements Serializable {
      *
      * @return the CVSS associated with this advisory.
      */
-    @Deprecated(forRemoval = true)
-    public CVSS getCvss() {
-        return cvss;
-    }
-
-    /**
-     * The CVSS associated with this advisory.
-     *
-     * @return the CVSS associated with this advisory.
-     */
     public CVSSSeverities getCvssSeverities() {
         return cvssSeverities;
     }
@@ -289,7 +272,7 @@ public class SecurityAdvisory implements Serializable {
                 + notificationsPermalink + '\'' + ", origin='" + origin + '\'' + ", permalink='" + permalink + '\''
                 + ", publishedAt=" + publishedAt + ", references=" + references + ", severity=" + severity
                 + ", summary='" + summary + '\'' + ", updatedAt=" + updatedAt + ", withdrawnAt=" + withdrawnAt
-                + ", classification=" + classification + ", cvss=" + cvss + ", cvssSeverities=" + cvssSeverities
+                + ", classification=" + classification + ", cvssSeverities=" + cvssSeverities
                 + ", cwes=" + cwes + ", vulnerabilities=" + vulnerabilities + '}';
     }
 
@@ -308,7 +291,7 @@ public class SecurityAdvisory implements Serializable {
                 && Objects.equals(publishedAt, that.publishedAt) && Objects.equals(references, that.references)
                 && severity == that.severity && Objects.equals(summary, that.summary)
                 && Objects.equals(updatedAt, that.updatedAt) && Objects.equals(withdrawnAt, that.withdrawnAt)
-                && Objects.equals(classification, that.classification) && Objects.equals(cvss, that.cvss)
+                && Objects.equals(classification, that.classification)
                 && Objects.equals(cvssSeverities, that.cvssSeverities) && Objects.equals(cwes, that.cwes)
                 && Objects.equals(vulnerabilities, that.vulnerabilities);
     }
@@ -316,7 +299,7 @@ public class SecurityAdvisory implements Serializable {
     @Override
     public int hashCode() {
         return Objects.hash(databaseId, description, ghsaId, id, identifiers, notificationsPermalink, origin, permalink,
-                publishedAt, references, severity, summary, updatedAt, withdrawnAt, classification, cvss,
+                publishedAt, references, severity, summary, updatedAt, withdrawnAt, classification,
                 cvssSeverities, cwes, vulnerabilities);
     }
 }

--- a/open-vulnerability-clients/src/main/resources/securityAdvisories.mustache
+++ b/open-vulnerability-clients/src/main/resources/securityAdvisories.mustache
@@ -53,10 +53,6 @@ query {
         }
       }
       classification
-      cvss {
-        score
-        vectorString
-      }
       cvssSeverities {
         cvssV3 {
           score

--- a/open-vulnerability-clients/src/test/resources/advisories.json
+++ b/open-vulnerability-clients/src/test/resources/advisories.json
@@ -9,897 +9,2621 @@
     "securityAdvisories": {
       "nodes": [
         {
-          "databaseId": 1275,
-          "description": "In Bootstrap 4 before 4.3.1 and Bootstrap 3 before 3.4.1, XSS is possible in the tooltip or popover data-template attribute. For more information, see: https://blog.getbootstrap.com/2019/02/13/bootstrap-4-3-1-and-3-4-1/",
-          "ghsaId": "GHSA-fxwm-579q-49qq",
-          "id": "MDE2OlNlY3VyaXR5QWR2aXNvcnlHSFNBLWZ4d20tNTc5cS00OXFx",
+          "databaseId": 205353,
+          "description": "There is a vulnerability in ActiveSupport if the new bytesplice method is called on a SafeBuffer with untrusted user input.\nThis vulnerability has been assigned the CVE identifier CVE-2023-28120.\n\nVersions Affected: All. Not affected: None Fixed Versions: 7.0.4.3, 6.1.7.3\n\n# Impact\n\nActiveSupport uses the SafeBuffer string subclass to tag strings as html_safe after they have been sanitized.\nWhen these strings are mutated, the tag is should be removed to mark them as no longer being html_safe.\n\nRuby 3.2 introduced a new bytesplice method which ActiveSupport did not yet understand to be a mutation.\nUsers on older versions of Ruby are likely unaffected.\n\nAll users running an affected release and using bytesplice should either upgrade or use one of the workarounds immediately.\n\n# Workarounds\n\nAvoid calling bytesplice on a SafeBuffer (html_safe) string with untrusted user input.\n",
+          "ghsaId": "GHSA-pj73-v5mw-pm9j",
+          "id": "GSA_kwCzR0hTQS1wajczLXY1bXctcG05as4AAyIp",
           "identifiers": [
             {
               "type": "GHSA",
-              "value": "GHSA-fxwm-579q-49qq"
+              "value": "GHSA-pj73-v5mw-pm9j"
             },
             {
               "type": "CVE",
-              "value": "CVE-2019-8331"
+              "value": "CVE-2023-28120"
             }
           ],
-          "notificationsPermalink": "https://github.com/advisories/GHSA-fxwm-579q-49qq/dependabot",
+          "notificationsPermalink": "https://github.com/advisories/GHSA-pj73-v5mw-pm9j/dependabot",
           "origin": "UNSPECIFIED",
-          "permalink": "https://github.com/advisories/GHSA-fxwm-579q-49qq",
-          "publishedAt": "2019-02-22T20:54:40Z",
+          "permalink": "https://github.com/advisories/GHSA-pj73-v5mw-pm9j",
+          "publishedAt": "2023-03-15T21:36:01Z",
           "references": [
             {
-              "url": "https://github.com/advisories/GHSA-fxwm-579q-49qq"
+              "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-28120"
+            },
+            {
+              "url": "https://discuss.rubyonrails.org/t/cve-2023-28120-possible-xss-security-vulnerability-in-safebuffer-bytesplice/82469"
+            },
+            {
+              "url": "https://github.com/rubysec/ruby-advisory-db/blob/master/gems/activesupport/CVE-2023-28120.yml"
+            },
+            {
+              "url": "https://github.com/rails/rails/commit/3cf23c3f891e2e81c977ea4ab83b62bc2a444b70"
+            },
+            {
+              "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/UPV6PVCX4VDJHLFFT42EXBBSGAWZICOW"
+            },
+            {
+              "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/ZE5W4MH6IE4DV7GELDK6ISCSTFLHKSYO"
+            },
+            {
+              "url": "https://security.netapp.com/advisory/ntap-20240202-0006"
+            },
+            {
+              "url": "https://www.debian.org/security/2023/dsa-5389"
+            },
+            {
+              "url": "https://github.com/advisories/GHSA-pj73-v5mw-pm9j"
             }
           ],
           "severity": "MODERATE",
-          "summary": "Moderate severity vulnerability that affects Bootstrap.Less, bootstrap, and bootstrap.sass",
-          "updatedAt": "2021-12-03T14:54:43Z",
+          "summary": "Possible XSS Security Vulnerability in SafeBuffer#bytesplice",
+          "updatedAt": "2025-01-10T13:51:03Z",
           "vulnerabilities": {
             "edges": [
               {
-                "node": {
-                  "severity": "MODERATE",
-                  "updatedAt": "2019-02-22T20:53:04Z",
-                  "firstPatchedVersion": {
-                    "identifier": "4.3.1"
-                  },
-                  "vulnerableVersionRange": ">= 4.0.0, < 4.3.1",
-                  "package": {
-                    "ecosystem": "NUGET",
-                    "name": "bootstrap"
-                  }
+                "severity": "MODERATE",
+                "updatedAt": "2023-03-15T21:36:03Z",
+                "firstPatchedVersion": {
+                  "identifier": "7.0.4.3"
+                },
+                "vulnerableVersionRange": ">= 7.0.0, < 7.0.4.3",
+                "package": {
+                  "ecosystem": "RUBYGEMS",
+                  "name": "activesupport"
                 }
               },
               {
-                "node": {
-                  "severity": "MODERATE",
-                  "updatedAt": "2019-02-22T20:53:04Z",
-                  "firstPatchedVersion": {
-                    "identifier": "4.3.1"
-                  },
-                  "vulnerableVersionRange": "< 4.3.1",
-                  "package": {
-                    "ecosystem": "NUGET",
-                    "name": "bootstrap.sass"
-                  }
-                }
-              },
-              {
-                "node": {
-                  "severity": "MODERATE",
-                  "updatedAt": "2019-02-22T20:53:04Z",
-                  "firstPatchedVersion": {
-                    "identifier": "3.4.1"
-                  },
-                  "vulnerableVersionRange": ">= 3.0.0, < 3.4.1",
-                  "package": {
-                    "ecosystem": "NUGET",
-                    "name": "bootstrap"
-                  }
-                }
-              },
-              {
-                "node": {
-                  "severity": "MODERATE",
-                  "updatedAt": "2019-02-22T20:53:04Z",
-                  "firstPatchedVersion": {
-                    "identifier": "3.4.1"
-                  },
-                  "vulnerableVersionRange": ">= 3.0.0, < 3.4.1",
-                  "package": {
-                    "ecosystem": "NUGET",
-                    "name": "Bootstrap.Less"
-                  }
+                "severity": "MODERATE",
+                "updatedAt": "2023-03-15T21:36:03Z",
+                "firstPatchedVersion": {
+                  "identifier": "6.1.7.3"
+                },
+                "vulnerableVersionRange": "< 6.1.7.3",
+                "package": {
+                  "ecosystem": "RUBYGEMS",
+                  "name": "activesupport"
                 }
               }
-            ],
-            "totalCount": 4,
-            "pageInfo": {
-              "hasNextPage": false,
-              "hasPreviousPage": false,
-              "endCursor": "Y3Vyc29yOnYyOpK5MjAxOS0wMi0yMlQxNTo1MzowNC0wNTowMM0H6w==",
-              "startCursor": "Y3Vyc29yOnYyOpK5MjAxOS0wMi0yMlQxNTo1MzowNC0wNTowMM0H6A=="
-            }
+            ]
           },
-          "cvss": {
-            "score": 0,
-            "vectorString": null
-          },
-          "cwes": {
-            "edges": [],
-            "totalCount": 0,
-            "pageInfo": {
-              "hasNextPage": false,
-              "hasPreviousPage": false
+          "classification": "GENERAL",
+          "cvssSeverities": {
+            "cvssV3": {
+              "score": 5.3,
+              "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N"
+            },
+            "cvssV4": {
+              "score": 0.0
             }
-          },
-          "withdrawnAt": null,
-          "classification": "GENERAL"
-        },
-        {
-          "databaseId": 1276,
-          "description": "In Bootstrap 4 before 4.3.1 and Bootstrap 3 before 3.4.1, XSS is possible in the tooltip or popover data-template attribute. For more information, see: https://blog.getbootstrap.com/2019/02/13/bootstrap-4-3-1-and-3-4-1/",
-          "ghsaId": "GHSA-wh77-3x4m-4q9g",
-          "id": "MDE2OlNlY3VyaXR5QWR2aXNvcnlHSFNBLXdoNzctM3g0bS00cTln",
-          "identifiers": [
-            {
-              "type": "GHSA",
-              "value": "GHSA-wh77-3x4m-4q9g"
-            },
-            {
-              "type": "CVE",
-              "value": "CVE-2019-8331"
-            }
-          ],
-          "notificationsPermalink": "https://github.com/advisories/GHSA-wh77-3x4m-4q9g/dependabot",
-          "origin": "UNSPECIFIED",
-          "permalink": "https://github.com/advisories/GHSA-wh77-3x4m-4q9g",
-          "publishedAt": "2019-02-22T20:54:27Z",
-          "references": [
-            {
-              "url": "https://github.com/advisories/GHSA-wh77-3x4m-4q9g"
-            }
-          ],
-          "severity": "MODERATE",
-          "summary": "Moderate severity vulnerability that affects bootstrap and bootstrap-sass",
-          "updatedAt": "2021-12-03T14:54:43Z",
-          "vulnerabilities": {
-            "edges": [
-              {
-                "node": {
-                  "severity": "MODERATE",
-                  "updatedAt": "2019-02-22T20:53:13Z",
-                  "firstPatchedVersion": {
-                    "identifier": "4.3.1"
-                  },
-                  "vulnerableVersionRange": ">= 4.0.0, < 4.3.1",
-                  "package": {
-                    "ecosystem": "NPM",
-                    "name": "bootstrap"
-                  }
-                }
-              },
-              {
-                "node": {
-                  "severity": "MODERATE",
-                  "updatedAt": "2019-02-22T20:53:13Z",
-                  "firstPatchedVersion": {
-                    "identifier": "3.4.1"
-                  },
-                  "vulnerableVersionRange": ">= 3.0.0, < 3.4.1",
-                  "package": {
-                    "ecosystem": "NPM",
-                    "name": "bootstrap"
-                  }
-                }
-              },
-              {
-                "node": {
-                  "severity": "MODERATE",
-                  "updatedAt": "2019-02-22T20:53:13Z",
-                  "firstPatchedVersion": {
-                    "identifier": "3.4.1"
-                  },
-                  "vulnerableVersionRange": ">= 3.0.0, < 3.4.1",
-                  "package": {
-                    "ecosystem": "NPM",
-                    "name": "bootstrap-sass"
-                  }
-                }
-              }
-            ],
-            "totalCount": 3,
-            "pageInfo": {
-              "hasNextPage": false,
-              "hasPreviousPage": false,
-              "endCursor": "Y3Vyc29yOnYyOpK5MjAxOS0wMi0yMlQxNTo1MzoxMy0wNTowMM0H7g==",
-              "startCursor": "Y3Vyc29yOnYyOpK5MjAxOS0wMi0yMlQxNTo1MzoxMy0wNTowMM0H7A=="
-            }
-          },
-          "cvss": {
-            "score": 0,
-            "vectorString": null
-          },
-          "cwes": {
-            "edges": [],
-            "totalCount": 0,
-            "pageInfo": {
-              "hasNextPage": false,
-              "hasPreviousPage": false
-            }
-          },
-          "withdrawnAt": null,
-          "classification": "GENERAL"
-        },
-        {
-          "databaseId": 2660,
-          "description": "Versions of `dojo` prior to 1.2.0 are vulnerable to Cross-Site Scripting (XSS). The package fails to sanitize HTML code in user-controlled input, allowing attackers to execute arbitrary JavaScript in the victim's browser.\n\n\n## Recommendation\n\nUpgrade to version 1.2.0 or later.",
-          "ghsaId": "GHSA-p82g-2xpp-m5r3",
-          "id": "MDE2OlNlY3VyaXR5QWR2aXNvcnlHSFNBLXA4MmctMnhwcC1tNXIz",
-          "identifiers": [
-            {
-              "type": "GHSA",
-              "value": "GHSA-p82g-2xpp-m5r3"
-            },
-            {
-              "type": "CVE",
-              "value": "CVE-2015-5654"
-            }
-          ],
-          "notificationsPermalink": "https://github.com/advisories/GHSA-p82g-2xpp-m5r3/dependabot",
-          "origin": "UNSPECIFIED",
-          "permalink": "https://github.com/advisories/GHSA-p82g-2xpp-m5r3",
-          "publishedAt": "2020-09-11T21:18:05Z",
-          "references": [
-            {
-              "url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-5654"
-            },
-            {
-              "url": "https://snyk.io/vuln/SNYK-JS-DOJO-174933"
-            },
-            {
-              "url": "https://www.npmjs.com/advisories/973"
-            },
-            {
-              "url": "https://nvd.nist.gov/vuln/detail/CVE-2015-5654"
-            },
-            {
-              "url": "http://jvn.jp/en/jp/JVN13456571/index.html"
-            },
-            {
-              "url": "http://jvndb.jvn.jp/jvndb/JVNDB-2015-000153"
-            },
-            {
-              "url": "http://www-01.ibm.com/support/docview.wss?uid=swg21975256"
-            },
-            {
-              "url": "http://www.securityfocus.com/bid/77026"
-            },
-            {
-              "url": "http://www.securitytracker.com/id/1034848"
-            },
-            {
-              "url": "https://github.com/advisories/GHSA-p82g-2xpp-m5r3"
-            }
-          ],
-          "severity": "MODERATE",
-          "summary": "Cross-Site Scripting in dojo",
-          "updatedAt": "2023-01-06T05:01:55Z",
-          "vulnerabilities": {
-            "edges": [
-              {
-                "node": {
-                  "severity": "MODERATE",
-                  "updatedAt": "2022-09-09T19:34:40Z",
-                  "firstPatchedVersion": {
-                    "identifier": "1.9.1"
-                  },
-                  "vulnerableVersionRange": "< 1.2.0",
-                  "package": {
-                    "ecosystem": "NPM",
-                    "name": "dojo"
-                  }
-                }
-              }
-            ],
-            "totalCount": 1,
-            "pageInfo": {
-              "hasNextPage": false,
-              "hasPreviousPage": false,
-              "endCursor": "Y3Vyc29yOnYyOpK5MjAyMi0wOS0wOVQxNTozNDo0MC0wNDowMM0R1Q==",
-              "startCursor": "Y3Vyc29yOnYyOpK5MjAyMi0wOS0wOVQxNTozNDo0MC0wNDowMM0R1Q=="
-            }
-          },
-          "cvss": {
-            "score": 5.4,
-            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N"
           },
           "cwes": {
             "edges": [
               {
-                "node": {
-                  "cweId": "CWE-79",
-                  "name": "Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')",
-                  "description": "The software does not neutralize or incorrectly neutralizes user-controllable input before it is placed in output that is used as a web page that is served to other users."
-                }
+                "cweId": "CWE-79",
+                "name": "Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')",
+                "description": "The product does not neutralize or incorrectly neutralizes user-controllable input before it is placed in output that is used as a web page that is served to other users."
               }
-            ],
-            "totalCount": 1,
-            "pageInfo": {
-              "hasNextPage": false,
-              "hasPreviousPage": false
-            }
+            ]
           },
-          "withdrawnAt": null,
-          "classification": "GENERAL"
+          "withdrawnAt": null
         },
         {
-          "databaseId": 2315,
-          "description": "### Impact\nServer JWT signing secret was included in static assets and served to clients.\n\nThis ALLOWS Flood's builtin authentication to be bypassed. Given Flood is granted access to rTorrent's SCGI interface (which is unprotected and ALLOWS arbitrary code execution) and usually wide-ranging privileges to files, along with Flood's lack of security controls against authenticated users, the severity of this vulnerability is **CRITICAL**. \n\n### Background\nCommit 8d11640b imported `config.js` to client (frontend) components to get `disableUsersAndAuth` configuration variable. Subsequently contents of `config.js` are compiled into static assets and served to users. Unfortunately `config.js` also includes `secret`.\n\nIntruders can use `secret` to sign authentication tokens themselves to bypass builtin access control of Flood.\n\n### Patches\nCommit 042cb4ce removed imports of `config.js` from client (frontend) components. Additionally an eslint rule was added to prevent config.js from being imported to client (frontend) components.\n\nCommit 103f53c8 provided a general mitigation to this kind of problem by searching static assets to ensure `secret` is not included before starting server (backend). \n\n### Workarounds\nUsers shall upgrade if they use Flood's builtin authentication system.\n\nWhile maintainers will do their best to support it, Flood cannot guarantee its in-house access control system can stand against determined attackers in high-stake environments. \n\n> Use `HTTP Basic Auth` or other battle-hardened authentication methods instead of Flood's in-house one. You can use `disableUsersAndAuth` to avoid duplicate authentication.\n\nUsers are advised to check out the [wiki](https://github.com/jesec/flood/wiki) for more information on security precautions.\n\n### References\n[Wiki - Security precautions](https://github.com/jesec/flood/wiki/Security-precautions)\n\n[Introduction to JSON Web Tokens](https://jwt.io/introduction/)\n\n### For more information\nIf you have any questions or comments about this advisory:\n* Open an issue in [issue tracker](https://github.com/jesec/flood/issues)\n* Email us at [jc@linux.com](mailto:jc@linux.com)",
-          "ghsaId": "GHSA-r587-7jh2-4qr3",
-          "id": "MDE2OlNlY3VyaXR5QWR2aXNvcnlHSFNBLXI1ODctN2poMi00cXIz",
+          "databaseId": 212057,
+          "description": "There is a deserialization of untrusted data vulnerability in\nthe Kredis JSON deserialization code. This vulnerability has\nbeen assigned the CVE identifier CVE-2023-27531.\n\n'Not affected: None.'\n'Versions Affected: All.'\n'Fixed Versions: 1.3.0.1'\n\nImpact\n  Carefully crafted JSON data processed by Kredis may result in\n  deserialization of untrusted data, potentially leading to\n  deserialization of unexpected objects in the system.\n\n  Any applications using Kredis with JSON are affected.\n\nReleases\n  The fixed releases are available at the normal locations.\n\nWorkarounds\n  There are no feasible workarounds for this issue.\n\nPatches\n  To aid users who aren’t able to upgrade immediately we have\n  provided patches for the two supported release series. They\n  are in git-am format and consist of a single changeset.\n\n  * 1-3-0-1-kredis.patch - Patch for 1.3.0 series\n\nCredits\n  Thank you ooooooo_k 7 for reporting this!\n",
+          "ghsaId": "GHSA-h2wm-p2vg-6pw4",
+          "id": "GSA_kwCzR0hTQS1oMndtLXAydmctNnB3NM4AAzxZ",
           "identifiers": [
             {
               "type": "GHSA",
-              "value": "GHSA-r587-7jh2-4qr3"
+              "value": "GHSA-h2wm-p2vg-6pw4"
+            },
+            {
+              "type": "CVE",
+              "value": "CVE-2023-27531"
             }
           ],
-          "notificationsPermalink": "https://github.com/advisories/GHSA-r587-7jh2-4qr3/dependabot",
+          "notificationsPermalink": "https://github.com/advisories/GHSA-h2wm-p2vg-6pw4/dependabot",
           "origin": "UNSPECIFIED",
-          "permalink": "https://github.com/advisories/GHSA-r587-7jh2-4qr3",
-          "publishedAt": "2020-08-26T19:32:50Z",
+          "permalink": "https://github.com/advisories/GHSA-h2wm-p2vg-6pw4",
+          "publishedAt": "2023-06-09T22:40:54Z",
           "references": [
             {
-              "url": "https://github.com/jesec/flood/security/advisories/GHSA-r587-7jh2-4qr3"
+              "url": "https://github.com/rails/kredis/commit/d576b7ae5c8d3d74eeb4bd84cad0aa64ffc299fa"
             },
             {
-              "url": "https://github.com/jesec/flood/commit/103f53c8d2963584e41bcf46ccc6fe0fabf179ca"
+              "url": "https://discuss.rubyonrails.org/t/cve-2023-27531-possible-deserialization-of-untrusted-data-vulnerability-in-kredis-json/82467#post_1"
             },
             {
-              "url": "https://github.com/jesec/flood/commit/d137107ac908526d43966607149fbaf00cfcedf0"
+              "url": "https://github.com/rails/kredis/releases/tag/v1.3.0.1"
             },
             {
-              "url": "https://github.com/advisories/GHSA-r587-7jh2-4qr3"
+              "url": "https://github.com/rubysec/ruby-advisory-db/blob/master/gems/kredis/CVE-2023-27531.yml"
+            },
+            {
+              "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-27531"
+            },
+            {
+              "url": "https://discuss.rubyonrails.org/t/cve-2023-27531-possible-deserialization-of-untrusted-data-vulnerability-in-kredis-json/82467"
+            },
+            {
+              "url": "https://github.com/advisories/GHSA-h2wm-p2vg-6pw4"
+            }
+          ],
+          "severity": "MODERATE",
+          "summary": "Kredis JSON Possible Deserialization of Untrusted Data Vulnerability",
+          "updatedAt": "2025-01-10T13:51:23Z",
+          "vulnerabilities": {
+            "edges": [
+              {
+                "severity": "MODERATE",
+                "updatedAt": "2023-06-09T22:40:57Z",
+                "firstPatchedVersion": {
+                  "identifier": "1.3.0.1"
+                },
+                "vulnerableVersionRange": "< 1.3.0.1",
+                "package": {
+                  "ecosystem": "RUBYGEMS",
+                  "name": "kredis"
+                }
+              }
+            ]
+          },
+          "classification": "GENERAL",
+          "cvssSeverities": {
+            "cvssV3": {
+              "score": 5.3,
+              "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N"
+            },
+            "cvssV4": {
+              "score": 0.0
+            }
+          },
+          "cwes": {
+            "edges": [
+              {
+                "cweId": "CWE-502",
+                "name": "Deserialization of Untrusted Data",
+                "description": "The product deserializes untrusted data without sufficiently verifying that the resulting data will be valid."
+              }
+            ]
+          },
+          "withdrawnAt": null
+        },
+        {
+          "databaseId": 213544,
+          "description": "The `redirect_to` method in Rails allows provided values to contain characters which are not legal in an HTTP header value. This results in the potential for downstream services which enforce RFC compliance on HTTP response headers to remove the assigned Location header. This vulnerability has been assigned the CVE identifier CVE-2023-28362.\n\nVersions Affected: All. Not affected: None Fixed Versions: 7.0.5.1, 6.1.7.4\n\n# Impact\n\nThis introduces the potential for a Cross-site-scripting (XSS) payload to be delivered on the now static redirection page. Note that this both requires user interaction and for a Rails app to be configured to allow redirects to external hosts (defaults to false in Rails >= 7.0.x).\n\n# Releases\n\nThe FIXED releases are available at the normal locations.\n\n# Workarounds\n\nAvoid providing user supplied URLs with arbitrary schemes to the `redirect_to` method.\n",
+          "ghsaId": "GHSA-4g8v-vg43-wpgf",
+          "id": "GSA_kwCzR0hTQS00Zzh2LXZnNDMtd3BnZs4AA0Io",
+          "identifiers": [
+            {
+              "type": "GHSA",
+              "value": "GHSA-4g8v-vg43-wpgf"
+            },
+            {
+              "type": "CVE",
+              "value": "CVE-2023-28362"
+            }
+          ],
+          "notificationsPermalink": "https://github.com/advisories/GHSA-4g8v-vg43-wpgf/dependabot",
+          "origin": "UNSPECIFIED",
+          "permalink": "https://github.com/advisories/GHSA-4g8v-vg43-wpgf",
+          "publishedAt": "2023-06-29T15:03:16Z",
+          "references": [
+            {
+              "url": "https://github.com/rails/rails/commit/1c3f93d1e90a3475f9ae2377ead25ccf11f71441"
+            },
+            {
+              "url": "https://github.com/rails/rails/commit/c9ab9b32bcdcfd8bcd55907f6c7b20b4e004cc23"
+            },
+            {
+              "url": "https://discuss.rubyonrails.org/t/cve-2023-28362-possible-xss-via-user-supplied-values-to-redirect-to/83132"
+            },
+            {
+              "url": "https://github.com/rubysec/ruby-advisory-db/blob/master/gems/actionpack/CVE-2023-28362.yml"
+            },
+            {
+              "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-28362"
+            },
+            {
+              "url": "https://github.com/rails/rails/commit/69e37c84e3f77d75566424c7d0015172d6a6fac5"
+            },
+            {
+              "url": "https://github.com/advisories/GHSA-4g8v-vg43-wpgf"
+            }
+          ],
+          "severity": "MODERATE",
+          "summary": "Actionpack has possible cross-site scripting vulnerability via User Supplied Values to redirect_to",
+          "updatedAt": "2025-01-10T13:51:38Z",
+          "vulnerabilities": {
+            "edges": [
+              {
+                "severity": "MODERATE",
+                "updatedAt": "2023-06-29T15:03:16Z",
+                "firstPatchedVersion": {
+                  "identifier": "6.1.7.4"
+                },
+                "vulnerableVersionRange": "< 6.1.7.4",
+                "package": {
+                  "ecosystem": "RUBYGEMS",
+                  "name": "actionpack"
+                }
+              },
+              {
+                "severity": "MODERATE",
+                "updatedAt": "2023-06-29T15:03:16Z",
+                "firstPatchedVersion": {
+                  "identifier": "7.0.5.1"
+                },
+                "vulnerableVersionRange": ">= 7.0.0, < 7.0.5.1",
+                "package": {
+                  "ecosystem": "RUBYGEMS",
+                  "name": "actionpack"
+                }
+              }
+            ]
+          },
+          "classification": "GENERAL",
+          "cvssSeverities": {
+            "cvssV3": {
+              "score": 4.0,
+              "vectorString": "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N"
+            },
+            "cvssV4": {
+              "score": 0.0
+            }
+          },
+          "cwes": {
+            "edges": [
+              {
+                "cweId": "CWE-116",
+                "name": "Improper Encoding or Escaping of Output",
+                "description": "The product prepares a structured message for communication with another component, but encoding or escaping of the data is either missing or done incorrectly. As a result, the intended structure of the message is not preserved."
+              }
+            ]
+          },
+          "withdrawnAt": null
+        },
+        {
+          "databaseId": 219023,
+          "description": "There is a possible file disclosure of locally encrypted files in Active Support. This vulnerability has been assigned the CVE identifier CVE-2023-38037.\n\nVersions Affected: >= 5.2.0 Not affected: < 5.2.0 Fixed Versions: 7.0.7.1, 6.1.7.5\n\n# Impact\nActiveSupport::EncryptedFile writes contents that will be encrypted to a temporary file. The temporary file’s permissions are defaulted to the user’s current umask settings, meaning that it’s possible for other users on the same system to read the contents of the temporary file.\n\nAttackers that have access to the file system could possibly read the contents of this temporary file while a user is editing it.\n\nAll users running an affected release should either upgrade or use one of the workarounds immediately.\n\n# Releases\nThe fixed releases are available at the normal locations.\n\n# Workarounds\nTo work around this issue, you can set your umask to be more restrictive like this:\n\n```ruby\n$ umask 0077\n```\n",
+          "ghsaId": "GHSA-cr5q-6q9f-rq6q",
+          "id": "GSA_kwCzR0hTQS1jcjVxLTZxOWYtcnE2cc4AA1eP",
+          "identifiers": [
+            {
+              "type": "GHSA",
+              "value": "GHSA-cr5q-6q9f-rq6q"
+            },
+            {
+              "type": "CVE",
+              "value": "CVE-2023-38037"
+            }
+          ],
+          "notificationsPermalink": "https://github.com/advisories/GHSA-cr5q-6q9f-rq6q/dependabot",
+          "origin": "UNSPECIFIED",
+          "permalink": "https://github.com/advisories/GHSA-cr5q-6q9f-rq6q",
+          "publishedAt": "2023-08-23T20:36:24Z",
+          "references": [
+            {
+              "url": "https://github.com/rails/rails/commit/a21d6edf35a60383dfa6c4da49e4b1aef5f00731"
+            },
+            {
+              "url": "https://github.com/rails/rails/releases/tag/v7.0.7.1"
+            },
+            {
+              "url": "https://github.com/rubysec/ruby-advisory-db/blob/master/gems/activesupport/CVE-2023-38037.yml"
+            },
+            {
+              "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-38037"
+            },
+            {
+              "url": "https://discuss.rubyonrails.org/t/cve-2023-38037-possible-file-disclosure-of-locally-encrypted-files/83544"
+            },
+            {
+              "url": "https://github.com/advisories/GHSA-cr5q-6q9f-rq6q"
+            }
+          ],
+          "severity": "MODERATE",
+          "summary": "Active Support Possibly Discloses Locally Encrypted Files",
+          "updatedAt": "2025-01-10T13:51:45Z",
+          "vulnerabilities": {
+            "edges": [
+              {
+                "severity": "MODERATE",
+                "updatedAt": "2023-08-23T20:36:25Z",
+                "firstPatchedVersion": {
+                  "identifier": "6.1.7.5"
+                },
+                "vulnerableVersionRange": ">= 5.2.0, < 6.1.7.5",
+                "package": {
+                  "ecosystem": "RUBYGEMS",
+                  "name": "activesupport"
+                }
+              },
+              {
+                "severity": "MODERATE",
+                "updatedAt": "2023-08-23T20:36:25Z",
+                "firstPatchedVersion": {
+                  "identifier": "7.0.7.1"
+                },
+                "vulnerableVersionRange": ">= 7.0.0, < 7.0.7.1",
+                "package": {
+                  "ecosystem": "RUBYGEMS",
+                  "name": "activesupport"
+                }
+              }
+            ]
+          },
+          "classification": "GENERAL",
+          "cvssSeverities": {
+            "cvssV3": {
+              "score": 5.5,
+              "vectorString": "CVSS:3.0/AV:L/AC:H/PR:L/UI:R/S:U/C:H/I:L/A:L"
+            },
+            "cvssV4": {
+              "score": 0.0
+            }
+          },
+          "cwes": {
+            "edges": [
+              {
+                "cweId": "CWE-377",
+                "name": "Insecure Temporary File",
+                "description": "Creating and using insecure temporary files can leave application and system data vulnerable to attack."
+              },
+              {
+                "cweId": "CWE-732",
+                "name": "Incorrect Permission Assignment for Critical Resource",
+                "description": "The product specifies permissions for a security-critical resource in a way that allows that resource to be read or modified by unintended actors."
+              }
+            ]
+          },
+          "withdrawnAt": null
+        },
+        {
+          "databaseId": 270275,
+          "description": "### Impact\nExecuting policy checks using custom schematron files via the CLI invokes an XSL transformation that may theoretically lead to a remote code execution (RCE) vulnerability.\n\n### Patches\nWe are currently working on a patch that will be released when ready.\n\n### Workarounds\nThis doesn't affect the standard validation and policy checks functionality, veraPDF's common use cases. Most veraPDF users don't insert any custom XSLT code into policy profiles, which are based on Schematron syntax rather than direct XSL transforms. For users who do, only load custom policy files from sources you trust.\n\n### References\nOriginal issue: #1488",
+          "ghsaId": "GHSA-4cx5-89vm-833x",
+          "id": "GSA_kwCzR0hTQS00Y3g1LTg5dm0tODMzeM4ABB_D",
+          "identifiers": [
+            {
+              "type": "GHSA",
+              "value": "GHSA-4cx5-89vm-833x"
+            },
+            {
+              "type": "CVE",
+              "value": "CVE-2024-52800"
+            }
+          ],
+          "notificationsPermalink": "https://github.com/advisories/GHSA-4cx5-89vm-833x/dependabot",
+          "origin": "UNSPECIFIED",
+          "permalink": "https://github.com/advisories/GHSA-4cx5-89vm-833x",
+          "publishedAt": "2024-12-02T17:15:24Z",
+          "references": [
+            {
+              "url": "https://github.com/veraPDF/veraPDF-library/security/advisories/GHSA-4cx5-89vm-833x"
+            },
+            {
+              "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-52800"
+            },
+            {
+              "url": "https://github.com/veraPDF/veraPDF-library/issues/1488"
+            },
+            {
+              "url": "https://github.com/advisories/GHSA-4cx5-89vm-833x"
+            }
+          ],
+          "severity": "LOW",
+          "summary": "veraPDF CLI has potential XXE (XML External Entity Injection) vulnerability",
+          "updatedAt": "2025-01-10T13:54:16Z",
+          "vulnerabilities": {
+            "edges": [
+              {
+                "severity": "LOW",
+                "updatedAt": "2024-12-23T17:13:28Z",
+                "firstPatchedVersion": {
+                  "identifier": "1.26.2"
+                },
+                "vulnerableVersionRange": "<= 1.26.1",
+                "package": {
+                  "ecosystem": "MAVEN",
+                  "name": "org.verapdf:core"
+                }
+              },
+              {
+                "severity": "LOW",
+                "updatedAt": "2024-12-23T17:13:28Z",
+                "firstPatchedVersion": {
+                  "identifier": "1.26.2"
+                },
+                "vulnerableVersionRange": "<= 1.26.1",
+                "package": {
+                  "ecosystem": "MAVEN",
+                  "name": "org.verapdf:core-jakarta"
+                }
+              },
+              {
+                "severity": "LOW",
+                "updatedAt": "2024-12-23T17:13:28Z",
+                "firstPatchedVersion": {
+                  "identifier": "1.26.2"
+                },
+                "vulnerableVersionRange": "<= 1.26.1",
+                "package": {
+                  "ecosystem": "MAVEN",
+                  "name": "org.verapdf:core-arlington"
+                }
+              },
+              {
+                "severity": "LOW",
+                "updatedAt": "2024-12-23T17:13:28Z",
+                "firstPatchedVersion": {
+                  "identifier": "1.26.2"
+                },
+                "vulnerableVersionRange": "<= 1.26.1",
+                "package": {
+                  "ecosystem": "MAVEN",
+                  "name": "org.verapdf:verapdf-library-jakarta"
+                }
+              },
+              {
+                "severity": "LOW",
+                "updatedAt": "2024-12-23T17:13:28Z",
+                "firstPatchedVersion": {
+                  "identifier": "1.26.2"
+                },
+                "vulnerableVersionRange": "<= 1.26.1",
+                "package": {
+                  "ecosystem": "MAVEN",
+                  "name": "org.verapdf:verapdf-library-arlington"
+                }
+              },
+              {
+                "severity": "LOW",
+                "updatedAt": "2025-01-10T13:54:16Z",
+                "firstPatchedVersion": {
+                  "identifier": "1.26.2"
+                },
+                "vulnerableVersionRange": "<= 1.26.1",
+                "package": {
+                  "ecosystem": "MAVEN",
+                  "name": "org.verapdf:verapdf-library"
+                }
+              }
+            ]
+          },
+          "classification": "GENERAL",
+          "cvssSeverities": {
+            "cvssV3": {
+              "score": 0.0
+            },
+            "cvssV4": {
+              "score": 2.3,
+              "vectorString": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:P/VC:L/VI:L/VA:N/SC:N/SI:N/SA:N"
+            }
+          },
+          "cwes": {
+            "edges": [
+              {
+                "cweId": "CWE-611",
+                "name": "Improper Restriction of XML External Entity Reference",
+                "description": "The product processes an XML document that can contain XML entities with URIs that resolve to documents outside of the intended sphere of control, causing the product to embed incorrect documents into its output."
+              }
+            ]
+          },
+          "withdrawnAt": null
+        },
+        {
+          "databaseId": 261362,
+          "description": "Vault’s SSH secrets engine did not require the valid_principals list to contain a value by default. If the valid_principals and default_user fields of the SSH secrets engine configuration are not set, an SSH certificate requested by an authorized user to Vault’s SSH secrets engine could be used to authenticate as any user on the host. Fixed in Vault Community Edition 1.17.6, and in Vault Enterprise 1.17.6, 1.16.10, and 1.15.15.",
+          "ghsaId": "GHSA-jg74-mwgw-v6x3",
+          "id": "GSA_kwCzR0hTQS1qZzc0LW13Z3ctdjZ4M84AA_zy",
+          "identifiers": [
+            {
+              "type": "GHSA",
+              "value": "GHSA-jg74-mwgw-v6x3"
+            },
+            {
+              "type": "CVE",
+              "value": "CVE-2024-7594"
+            }
+          ],
+          "notificationsPermalink": "https://github.com/advisories/GHSA-jg74-mwgw-v6x3/dependabot",
+          "origin": "UNSPECIFIED",
+          "permalink": "https://github.com/advisories/GHSA-jg74-mwgw-v6x3",
+          "publishedAt": "2024-09-26T21:31:11Z",
+          "references": [
+            {
+              "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-7594"
+            },
+            {
+              "url": "https://discuss.hashicorp.com/t/hcsec-2024-20-vault-ssh-secrets-engine-configuration-did-not-restrict-valid-principals-by-default/70251"
+            },
+            {
+              "url": "https://pkg.go.dev/vuln/GO-2024-3162"
+            },
+            {
+              "url": "https://security.netapp.com/advisory/ntap-20250110-0007"
+            },
+            {
+              "url": "https://github.com/advisories/GHSA-jg74-mwgw-v6x3"
+            }
+          ],
+          "severity": "HIGH",
+          "summary": "Vault SSH Secrets Engine Configuration Did Not Restrict Valid Principals By Default",
+          "updatedAt": "2025-01-10T15:31:33Z",
+          "vulnerabilities": {
+            "edges": [
+              {
+                "severity": "HIGH",
+                "updatedAt": "2024-09-26T21:53:45Z",
+                "firstPatchedVersion": {
+                  "identifier": "1.17.6"
+                },
+                "vulnerableVersionRange": ">= 1.7.7, < 1.17.6",
+                "package": {
+                  "ecosystem": "GO",
+                  "name": "github.com/hashicorp/vault"
+                }
+              }
+            ]
+          },
+          "classification": "GENERAL",
+          "cvssSeverities": {
+            "cvssV3": {
+              "score": 7.5,
+              "vectorString": "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:H"
+            },
+            "cvssV4": {
+              "score": 7.7,
+              "vectorString": "CVSS:4.0/AV:N/AC:L/AT:P/PR:L/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N"
+            }
+          },
+          "cwes": {
+            "edges": [
+              {
+                "cweId": "CWE-732",
+                "name": "Incorrect Permission Assignment for Critical Resource",
+                "description": "The product specifies permissions for a security-critical resource in a way that allows that resource to be read or modified by unintended actors."
+              }
+            ]
+          },
+          "withdrawnAt": null
+        },
+        {
+          "databaseId": 265559,
+          "description": "A vulnerability was identified in Consul and Consul Enterprise such that the server response did not explicitly set a Content-Type HTTP header, allowing user-provided inputs to be misinterpreted and lead to reflected XSS.",
+          "ghsaId": "GHSA-99wr-c2px-grmh",
+          "id": "GSA_kwCzR0hTQS05OXdyLWMycHgtZ3JtaM4ABA1X",
+          "identifiers": [
+            {
+              "type": "GHSA",
+              "value": "GHSA-99wr-c2px-grmh"
+            },
+            {
+              "type": "CVE",
+              "value": "CVE-2024-10086"
+            }
+          ],
+          "notificationsPermalink": "https://github.com/advisories/GHSA-99wr-c2px-grmh/dependabot",
+          "origin": "UNSPECIFIED",
+          "permalink": "https://github.com/advisories/GHSA-99wr-c2px-grmh",
+          "publishedAt": "2024-10-31T00:30:36Z",
+          "references": [
+            {
+              "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-10086"
+            },
+            {
+              "url": "https://discuss.hashicorp.com/t/hcsec-2024-24-consul-vulnerable-to-reflected-xss-on-content-type-error-manipulation"
+            },
+            {
+              "url": "https://github.com/hashicorp/consul/commit/07fae7bb0be8593cc98c38b1ef4a49ed9188932f"
+            },
+            {
+              "url": "https://github.com/advisories/GHSA-99wr-c2px-grmh"
+            },
+            {
+              "url": "https://security.netapp.com/advisory/ntap-20250110-0006"
+            }
+          ],
+          "severity": "MODERATE",
+          "summary": "Hashicorp Consul Cross-site Scripting vulnerability",
+          "updatedAt": "2025-01-10T15:31:34Z",
+          "vulnerabilities": {
+            "edges": [
+              {
+                "severity": "MODERATE",
+                "updatedAt": "2024-10-31T14:55:00Z",
+                "firstPatchedVersion": {
+                  "identifier": "1.20.0"
+                },
+                "vulnerableVersionRange": ">= 1.4.1, < 1.20.0",
+                "package": {
+                  "ecosystem": "GO",
+                  "name": "github.com/hashicorp/consul"
+                }
+              }
+            ]
+          },
+          "classification": "GENERAL",
+          "cvssSeverities": {
+            "cvssV3": {
+              "score": 6.1,
+              "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N"
+            },
+            "cvssV4": {
+              "score": 5.3,
+              "vectorString": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:P/VC:N/VI:N/VA:N/SC:L/SI:L/SA:N"
+            }
+          },
+          "cwes": {
+            "edges": [
+              {
+                "cweId": "CWE-79",
+                "name": "Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')",
+                "description": "The product does not neutralize or incorrectly neutralizes user-controllable input before it is placed in output that is used as a web page that is served to other users."
+              }
+            ]
+          },
+          "withdrawnAt": null
+        },
+        {
+          "databaseId": 265560,
+          "description": "A vulnerability was identified in Consul and Consul Enterprise (\"Consul\") such that using URL paths in L7 traffic intentions could bypass HTTP request path-based access rules.",
+          "ghsaId": "GHSA-chgm-7r52-whjj",
+          "id": "GSA_kwCzR0hTQS1jaGdtLTdyNTItd2hqas4ABA1Y",
+          "identifiers": [
+            {
+              "type": "GHSA",
+              "value": "GHSA-chgm-7r52-whjj"
+            },
+            {
+              "type": "CVE",
+              "value": "CVE-2024-10005"
+            }
+          ],
+          "notificationsPermalink": "https://github.com/advisories/GHSA-chgm-7r52-whjj/dependabot",
+          "origin": "UNSPECIFIED",
+          "permalink": "https://github.com/advisories/GHSA-chgm-7r52-whjj",
+          "publishedAt": "2024-10-31T00:30:36Z",
+          "references": [
+            {
+              "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-10005"
+            },
+            {
+              "url": "https://discuss.hashicorp.com/t/hcsec-2024-22-consul-l7-intentions-vulnerable-to-url-path-bypass"
+            },
+            {
+              "url": "https://github.com/hashicorp/consul/pull/21816"
+            },
+            {
+              "url": "https://github.com/hashicorp/consul/commit/d9206fc7e284a9244af4d62f8653a63ca30bd00c"
+            },
+            {
+              "url": "https://github.com/advisories/GHSA-chgm-7r52-whjj"
+            },
+            {
+              "url": "https://security.netapp.com/advisory/ntap-20250110-0004"
+            }
+          ],
+          "severity": "HIGH",
+          "summary": "Hashicorp Consul Path Traversal vulnerability",
+          "updatedAt": "2025-01-10T15:32:35Z",
+          "vulnerabilities": {
+            "edges": [
+              {
+                "severity": "HIGH",
+                "updatedAt": "2024-10-31T14:49:28Z",
+                "firstPatchedVersion": {
+                  "identifier": "1.20.1"
+                },
+                "vulnerableVersionRange": ">= 1.9.0, < 1.20.1",
+                "package": {
+                  "ecosystem": "GO",
+                  "name": "github.com/hashicorp/consul"
+                }
+              }
+            ]
+          },
+          "classification": "GENERAL",
+          "cvssSeverities": {
+            "cvssV3": {
+              "score": 8.1,
+              "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:N"
+            },
+            "cvssV4": {
+              "score": 8.6,
+              "vectorString": "CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:H/VI:H/VA:N/SC:N/SI:N/SA:N"
+            }
+          },
+          "cwes": {
+            "edges": [
+              {
+                "cweId": "CWE-22",
+                "name": "Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')",
+                "description": "The product uses external input to construct a pathname that is intended to identify a file or directory that is located underneath a restricted parent directory, but the product does not properly neutralize special elements within the pathname that can cause the pathname to resolve to a location that is outside of the restricted directory."
+              }
+            ]
+          },
+          "withdrawnAt": null
+        },
+        {
+          "databaseId": 265561,
+          "description": "A vulnerability was identified in Consul and Consul Enterprise (\"Consul\") such that using Headers in L7 traffic intentions could bypass HTTP header based access rules.",
+          "ghsaId": "GHSA-5c4w-8hhh-3c3h",
+          "id": "GSA_kwCzR0hTQS01YzR3LThoaGgtM2MzaM4ABA1Z",
+          "identifiers": [
+            {
+              "type": "GHSA",
+              "value": "GHSA-5c4w-8hhh-3c3h"
+            },
+            {
+              "type": "CVE",
+              "value": "CVE-2024-10006"
+            }
+          ],
+          "notificationsPermalink": "https://github.com/advisories/GHSA-5c4w-8hhh-3c3h/dependabot",
+          "origin": "UNSPECIFIED",
+          "permalink": "https://github.com/advisories/GHSA-5c4w-8hhh-3c3h",
+          "publishedAt": "2024-10-31T00:30:36Z",
+          "references": [
+            {
+              "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-10006"
+            },
+            {
+              "url": "https://discuss.hashicorp.com/t/hcsec-2024-23-consul-l7-intentions-vulnerable-to-headers-bypass"
+            },
+            {
+              "url": "https://github.com/hashicorp/consul/pull/21816"
+            },
+            {
+              "url": "https://github.com/hashicorp/consul/commit/d9206fc7e284a9244af4d62f8653a63ca30bd00c"
+            },
+            {
+              "url": "https://security.netapp.com/advisory/ntap-20250110-0005"
+            },
+            {
+              "url": "https://github.com/advisories/GHSA-5c4w-8hhh-3c3h"
+            }
+          ],
+          "severity": "MODERATE",
+          "summary": "Hashicorp Consul Improper Neutralization of HTTP Headers for Scripting Syntax vulnerability",
+          "updatedAt": "2025-01-10T15:32:35Z",
+          "vulnerabilities": {
+            "edges": [
+              {
+                "severity": "MODERATE",
+                "updatedAt": "2024-10-31T14:49:34Z",
+                "firstPatchedVersion": {
+                  "identifier": "1.20.1"
+                },
+                "vulnerableVersionRange": ">= 1.9.0, < 1.20.1",
+                "package": {
+                  "ecosystem": "GO",
+                  "name": "github.com/hashicorp/consul"
+                }
+              }
+            ]
+          },
+          "classification": "GENERAL",
+          "cvssSeverities": {
+            "cvssV3": {
+              "score": 8.3,
+              "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:L"
+            },
+            "cvssV4": {
+              "score": 6.9,
+              "vectorString": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:N/SC:L/SI:L/SA:L"
+            }
+          },
+          "cwes": {
+            "edges": [
+              {
+                "cweId": "CWE-116",
+                "name": "Improper Encoding or Escaping of Output",
+                "description": "The product prepares a structured message for communication with another component, but encoding or escaping of the data is either missing or done incorrectly. As a result, the intended structure of the message is not preserved."
+              },
+              {
+                "cweId": "CWE-644",
+                "name": "Improper Neutralization of HTTP Headers for Scripting Syntax",
+                "description": "The product does not neutralize or incorrectly neutralizes web scripting syntax in HTTP headers that can be used by web browser components that can process raw headers, such as Flash."
+              }
+            ]
+          },
+          "withdrawnAt": null
+        },
+        {
+          "databaseId": 272922,
+          "description": "Applications serving static resources through the functional web frameworks WebMvc.fn or WebFlux.fn are vulnerable to path traversal attacks. An attacker can craft malicious HTTP requests and obtain any file on the file system that is also accessible to the process in which the Spring application is running.",
+          "ghsaId": "GHSA-g5vr-rgqm-vf78",
+          "id": "GSA_kwCzR0hTQS1nNXZyLXJncW0tdmY3OM4ABCoa",
+          "identifiers": [
+            {
+              "type": "GHSA",
+              "value": "GHSA-g5vr-rgqm-vf78"
+            },
+            {
+              "type": "CVE",
+              "value": "CVE-2024-38819"
+            }
+          ],
+          "notificationsPermalink": "https://github.com/advisories/GHSA-g5vr-rgqm-vf78/dependabot",
+          "origin": "UNSPECIFIED",
+          "permalink": "https://github.com/advisories/GHSA-g5vr-rgqm-vf78",
+          "publishedAt": "2024-12-19T18:31:38Z",
+          "references": [
+            {
+              "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-38819"
+            },
+            {
+              "url": "https://spring.io/security/cve-2024-38819"
+            },
+            {
+              "url": "https://github.com/spring-projects/spring-framework/issues/33689"
+            },
+            {
+              "url": "https://github.com/spring-projects/spring-framework/commit/3bfbe30a7814c9ea1556d40df9bd87ddb3ba372d"
+            },
+            {
+              "url": "https://github.com/spring-projects/spring-framework/commit/fb7890d73975a3d9e0763e0926df2bd0a608e87e"
+            },
+            {
+              "url": "https://security.netapp.com/advisory/ntap-20250110-0010"
+            },
+            {
+              "url": "https://github.com/advisories/GHSA-g5vr-rgqm-vf78"
+            }
+          ],
+          "severity": "HIGH",
+          "summary": "Spring Framework Path Traversal vulnerability",
+          "updatedAt": "2025-01-10T15:32:36Z",
+          "vulnerabilities": {
+            "edges": [
+              {
+                "severity": "HIGH",
+                "updatedAt": "2024-12-19T22:35:07Z",
+                "firstPatchedVersion": {
+                  "identifier": "6.1.14"
+                },
+                "vulnerableVersionRange": "< 6.1.14",
+                "package": {
+                  "ecosystem": "MAVEN",
+                  "name": "org.springframework:spring-webflux"
+                }
+              },
+              {
+                "severity": "HIGH",
+                "updatedAt": "2024-12-19T22:35:07Z",
+                "firstPatchedVersion": {
+                  "identifier": "6.1.14"
+                },
+                "vulnerableVersionRange": "< 6.1.14",
+                "package": {
+                  "ecosystem": "MAVEN",
+                  "name": "org.springframework:spring-webmvc"
+                }
+              }
+            ]
+          },
+          "classification": "GENERAL",
+          "cvssSeverities": {
+            "cvssV3": {
+              "score": 7.5,
+              "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
+            },
+            "cvssV4": {
+              "score": 0.0
+            }
+          },
+          "cwes": {
+            "edges": [
+              {
+                "cweId": "CWE-22",
+                "name": "Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')",
+                "description": "The product uses external input to construct a pathname that is intended to identify a file or directory that is located underneath a restricted parent directory, but the product does not properly neutralize special elements within the pathname that can cause the pathname to resolve to a location that is outside of the restricted directory."
+              }
+            ]
+          },
+          "withdrawnAt": null
+        },
+        {
+          "databaseId": 226122,
+          "description": "Relative library resolution in linux container-executor binary in Apache Hadoop 3.3.1-3.3.4 on Linux allows local user to gain root privileges. If the YARN cluster is accepting work from remote (authenticated) users, this MAY permit remote users to gain root privileges.\n\nHadoop 3.3.0 updated the \" YARN Secure Containers https://hadoop.apache.org/docs/stable/hadoop-yarn/hadoop-yarn-site/SecureContainer.html \" to add a feature for executing user-submitted applications in isolated linux containers.\n\nThe native binary HADOOP_HOME/bin/container-executor is used to launch these containers; it must be owned by root and have the suid bit set in order for the YARN processes to run the containers as the specific users submitting the jobs.\n\nThe patch \" YARN-10495 https://issues.apache.org/jira/browse/YARN-10495 . make the rpath of container-executor configurable\" modified the library loading path for loading .so files from \"$ORIGIN/\" to \"\"$ORIGIN/:../lib/native/\". This is the a path through which libcrypto.so is located. Thus it is is possible for a user with reduced privileges to install a malicious libcrypto library into a path to which they have write access, invoke the container-executor command, and have their modified library executed as root.\nIf the YARN cluster is accepting work from remote (authenticated) users, and these users' submitted job are executed in the physical host, rather than a container, then the CVE permits remote users to gain root privileges.\n\nThe fix for the vulnerability is to revert the change, which is done in  YARN-11441 https://issues.apache.org/jira/browse/YARN-11441 , \"Revert YARN-10495\". This patch is in hadoop-3.3.5.\n\nTo determine whether a version of container-executor is vulnerable, use the readelf command. If the RUNPATH or RPATH value contains the relative path \"./lib/native/\" then it  is at risk\n\n$ readelf -d container-executor|grep 'RUNPATH\\|RPATH' \n0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN/:../lib/native/]\n\nIf it does not, then it is safe:\n\n$ readelf -d container-executor|grep 'RUNPATH\\|RPATH' \n0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN/]\n\nFor an at-risk version of container-executor to enable privilege escalation, the owner must be root and the suid bit must be set\n\n$ ls -laF /opt/hadoop/bin/container-executor\n---Sr-s---. 1 root hadoop 802968 May 9 20:21 /opt/hadoop/bin/container-executor\n\nA safe installation lacks the suid bit; ideally is also not owned by root.\n\n$ ls -laF /opt/hadoop/bin/container-executor\n-rwxr-xr-x. 1 yarn hadoop 802968 May 9 20:21 /opt/hadoop/bin/container-executor\n\nThis configuration does not support Yarn Secure Containers, but all other hadoop services, including YARN job execution outside secure containers continue to work.",
+          "ghsaId": "GHSA-94jh-j374-9r3j",
+          "id": "GSA_kwCzR0hTQS05NGpoLWozNzQtOXIzas4AA3NK",
+          "identifiers": [
+            {
+              "type": "GHSA",
+              "value": "GHSA-94jh-j374-9r3j"
+            },
+            {
+              "type": "CVE",
+              "value": "CVE-2023-26031"
+            }
+          ],
+          "notificationsPermalink": "https://github.com/advisories/GHSA-94jh-j374-9r3j/dependabot",
+          "origin": "UNSPECIFIED",
+          "permalink": "https://github.com/advisories/GHSA-94jh-j374-9r3j",
+          "publishedAt": "2023-11-16T09:30:24Z",
+          "references": [
+            {
+              "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-26031"
+            },
+            {
+              "url": "https://hadoop.apache.org/cve_list.html"
+            },
+            {
+              "url": "https://issues.apache.org/jira/browse/YARN-11441"
+            },
+            {
+              "url": "https://lists.apache.org/thread/q9qpdlv952gb4kphpndd5phvl7fkh71r"
+            },
+            {
+              "url": "https://github.com/apache/hadoop/commit/10e7ca481c8cd0548d903d39d8581291e533bf12"
+            },
+            {
+              "url": "https://github.com/apache/hadoop/commit/7d3c8ef6064efd132828765e52e961977aebbf47"
+            },
+            {
+              "url": "https://security.netapp.com/advisory/ntap-20240112-0001"
+            },
+            {
+              "url": "https://github.com/advisories/GHSA-94jh-j374-9r3j"
+            }
+          ],
+          "severity": "HIGH",
+          "summary": "Apache Hadoop allows local user to gain root privileges",
+          "updatedAt": "2025-01-10T15:53:11Z",
+          "vulnerabilities": {
+            "edges": [
+              {
+                "severity": "HIGH",
+                "updatedAt": "2023-11-16T21:02:11Z",
+                "firstPatchedVersion": {
+                  "identifier": "3.3.5"
+                },
+                "vulnerableVersionRange": ">= 3.3.1, < 3.3.5",
+                "package": {
+                  "ecosystem": "MAVEN",
+                  "name": "org.apache.hadoop:hadoop-yarn-project"
+                }
+              }
+            ]
+          },
+          "classification": "GENERAL",
+          "cvssSeverities": {
+            "cvssV3": {
+              "score": 7.5,
+              "vectorString": "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:H"
+            },
+            "cvssV4": {
+              "score": 7.7,
+              "vectorString": "CVSS:4.0/AV:N/AC:L/AT:P/PR:L/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N"
+            }
+          },
+          "cwes": {
+            "edges": [
+              {
+                "cweId": "CWE-426",
+                "name": "Untrusted Search Path",
+                "description": "The product searches for critical resources using an externally-supplied search path that can point to resources that are not under the product's direct control."
+              }
+            ]
+          },
+          "withdrawnAt": null
+        },
+        {
+          "databaseId": 270250,
+          "description": "The usage of String.toLowerCase() and String.toUpperCase() has some Locale dependent exceptions that could potentially result in authorization rules not working properly.",
+          "ghsaId": "GHSA-q3v6-hm2v-pw99",
+          "id": "GSA_kwCzR0hTQS1xM3Y2LWhtMnYtcHc5Oc4ABB-q",
+          "identifiers": [
+            {
+              "type": "GHSA",
+              "value": "GHSA-q3v6-hm2v-pw99"
+            },
+            {
+              "type": "CVE",
+              "value": "CVE-2024-38827"
+            }
+          ],
+          "notificationsPermalink": "https://github.com/advisories/GHSA-q3v6-hm2v-pw99/dependabot",
+          "origin": "UNSPECIFIED",
+          "permalink": "https://github.com/advisories/GHSA-q3v6-hm2v-pw99",
+          "publishedAt": "2024-12-02T15:31:41Z",
+          "references": [
+            {
+              "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-38827"
+            },
+            {
+              "url": "https://spring.io/security/cve-2024-38827"
+            },
+            {
+              "url": "https://github.com/spring-projects/spring-framework/issues/33708"
+            },
+            {
+              "url": "https://github.com/spring-projects/spring-framework/commit/11d4272ff48b4a4dabc4b28dfbff0364a4204bc9"
+            },
+            {
+              "url": "https://github.com/spring-projects/spring-framework/issues/34232"
+            },
+            {
+              "url": "https://github.com/advisories/GHSA-q3v6-hm2v-pw99"
+            }
+          ],
+          "severity": "MODERATE",
+          "summary": "Spring Framework has Authorization Bypass for Case Sensitive Comparisons",
+          "updatedAt": "2025-01-10T15:59:24Z",
+          "vulnerabilities": {
+            "edges": [
+              {
+                "severity": "MODERATE",
+                "updatedAt": "2025-01-10T15:59:24Z",
+                "firstPatchedVersion": {
+                  "identifier": "5.7.14"
+                },
+                "vulnerableVersionRange": "< 5.7.14",
+                "package": {
+                  "ecosystem": "MAVEN",
+                  "name": "org.springframework.security:spring-security-core"
+                }
+              },
+              {
+                "severity": "MODERATE",
+                "updatedAt": "2025-01-10T15:59:24Z",
+                "firstPatchedVersion": {
+                  "identifier": "5.8.16"
+                },
+                "vulnerableVersionRange": ">= 5.8.0, < 5.8.16",
+                "package": {
+                  "ecosystem": "MAVEN",
+                  "name": "org.springframework.security:spring-security-core"
+                }
+              },
+              {
+                "severity": "MODERATE",
+                "updatedAt": "2025-01-10T15:59:24Z",
+                "firstPatchedVersion": {
+                  "identifier": "6.0.14"
+                },
+                "vulnerableVersionRange": ">= 6.0.0, < 6.0.14",
+                "package": {
+                  "ecosystem": "MAVEN",
+                  "name": "org.springframework.security:spring-security-core"
+                }
+              },
+              {
+                "severity": "MODERATE",
+                "updatedAt": "2025-01-10T15:59:24Z",
+                "firstPatchedVersion": {
+                  "identifier": "6.1.12"
+                },
+                "vulnerableVersionRange": ">= 6.1.0, < 6.1.12",
+                "package": {
+                  "ecosystem": "MAVEN",
+                  "name": "org.springframework.security:spring-security-core"
+                }
+              },
+              {
+                "severity": "MODERATE",
+                "updatedAt": "2025-01-10T15:59:24Z",
+                "firstPatchedVersion": {
+                  "identifier": "6.2.8"
+                },
+                "vulnerableVersionRange": ">= 6.2.0, < 6.2.8",
+                "package": {
+                  "ecosystem": "MAVEN",
+                  "name": "org.springframework.security:spring-security-core"
+                }
+              },
+              {
+                "severity": "MODERATE",
+                "updatedAt": "2025-01-10T15:59:24Z",
+                "firstPatchedVersion": {
+                  "identifier": "6.3.5"
+                },
+                "vulnerableVersionRange": ">= 6.3.0, < 6.3.5",
+                "package": {
+                  "ecosystem": "MAVEN",
+                  "name": "org.springframework.security:spring-security-core"
+                }
+              }
+            ]
+          },
+          "classification": "GENERAL",
+          "cvssSeverities": {
+            "cvssV3": {
+              "score": 4.8,
+              "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:N"
+            },
+            "cvssV4": {
+              "score": 6.3,
+              "vectorString": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:L/VI:L/VA:N/SC:N/SI:N/SA:N"
+            }
+          },
+          "cwes": {
+            "edges": [
+              {
+                "cweId": "CWE-639",
+                "name": "Authorization Bypass Through User-Controlled Key",
+                "description": "The system's authorization functionality does not prevent one user from gaining access to another user's data or record by modifying the key value identifying the data."
+              }
+            ]
+          },
+          "withdrawnAt": null
+        },
+        {
+          "databaseId": 236159,
+          "description": "Mattermost fails to properly authorize the requests fetching team associated AD/LDAP groups, allowing a user to fetch details of AD/LDAP groups of a team that they are not a member of. \n\n",
+          "ghsaId": "GHSA-7v3v-984v-h74r",
+          "id": "GSA_kwCzR0hTQS03djN2LTk4NHYtaDc0cs4AA5p_",
+          "identifiers": [
+            {
+              "type": "GHSA",
+              "value": "GHSA-7v3v-984v-h74r"
+            },
+            {
+              "type": "CVE",
+              "value": "CVE-2024-23493"
+            }
+          ],
+          "notificationsPermalink": "https://github.com/advisories/GHSA-7v3v-984v-h74r/dependabot",
+          "origin": "UNSPECIFIED",
+          "permalink": "https://github.com/advisories/GHSA-7v3v-984v-h74r",
+          "publishedAt": "2024-02-29T09:30:34Z",
+          "references": [
+            {
+              "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-23493"
+            },
+            {
+              "url": "https://mattermost.com/security-updates"
+            },
+            {
+              "url": "https://github.com/advisories/GHSA-7v3v-984v-h74r"
+            }
+          ],
+          "severity": "MODERATE",
+          "summary": "Mattermost leaks details of AD/LDAP groups of a teams",
+          "updatedAt": "2025-01-10T18:32:13Z",
+          "vulnerabilities": {
+            "edges": [
+              {
+                "severity": "MODERATE",
+                "updatedAt": "2024-02-29T22:48:26Z",
+                "firstPatchedVersion": {
+                  "identifier": "9.4.2"
+                },
+                "vulnerableVersionRange": ">= 9.4.0, < 9.4.2",
+                "package": {
+                  "ecosystem": "GO",
+                  "name": "github.com/mattermost/mattermost/server/v8"
+                }
+              },
+              {
+                "severity": "MODERATE",
+                "updatedAt": "2024-02-29T22:48:26Z",
+                "firstPatchedVersion": {
+                  "identifier": "9.3.1"
+                },
+                "vulnerableVersionRange": ">= 9.3.0, < 9.3.1",
+                "package": {
+                  "ecosystem": "GO",
+                  "name": "github.com/mattermost/mattermost/server/v8"
+                }
+              },
+              {
+                "severity": "MODERATE",
+                "updatedAt": "2024-02-29T22:48:26Z",
+                "firstPatchedVersion": {
+                  "identifier": "9.2.5"
+                },
+                "vulnerableVersionRange": ">= 9.2.0, < 9.2.5",
+                "package": {
+                  "ecosystem": "GO",
+                  "name": "github.com/mattermost/mattermost/server/v8"
+                }
+              }
+            ]
+          },
+          "classification": "GENERAL",
+          "cvssSeverities": {
+            "cvssV3": {
+              "score": 4.3,
+              "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N"
+            },
+            "cvssV4": {
+              "score": 5.3,
+              "vectorString": "CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:L/VI:N/VA:N/SC:N/SI:N/SA:N"
+            }
+          },
+          "cwes": {
+            "edges": [
+              {
+                "cweId": "CWE-200",
+                "name": "Exposure of Sensitive Information to an Unauthorized Actor",
+                "description": "The product exposes sensitive information to an actor that is not explicitly authorized to have access to that information."
+              },
+              {
+                "cweId": "CWE-862",
+                "name": "Missing Authorization",
+                "description": "The product does not perform an authorization check when an actor attempts to access a resource or perform an action."
+              }
+            ]
+          },
+          "withdrawnAt": null
+        },
+        {
+          "databaseId": 236160,
+          "description": "Mattermost fails to properly validate the length of the emoji value in the custom user status, allowing an attacker to send multiple times a very long string as an emoji value causing high resource consumption and possibly crashing the server.\n\n",
+          "ghsaId": "GHSA-6mx3-9qfh-77gj",
+          "id": "GSA_kwCzR0hTQS02bXgzLTlxZmgtNzdnas4AA5qA",
+          "identifiers": [
+            {
+              "type": "GHSA",
+              "value": "GHSA-6mx3-9qfh-77gj"
+            },
+            {
+              "type": "CVE",
+              "value": "CVE-2024-24988"
+            }
+          ],
+          "notificationsPermalink": "https://github.com/advisories/GHSA-6mx3-9qfh-77gj/dependabot",
+          "origin": "UNSPECIFIED",
+          "permalink": "https://github.com/advisories/GHSA-6mx3-9qfh-77gj",
+          "publishedAt": "2024-02-29T09:30:34Z",
+          "references": [
+            {
+              "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-24988"
+            },
+            {
+              "url": "https://mattermost.com/security-updates"
+            },
+            {
+              "url": "https://github.com/advisories/GHSA-6mx3-9qfh-77gj"
+            }
+          ],
+          "severity": "MODERATE",
+          "summary": "Mattermost denial of service through long emoji value",
+          "updatedAt": "2025-01-10T18:32:26Z",
+          "vulnerabilities": {
+            "edges": [
+              {
+                "severity": "MODERATE",
+                "updatedAt": "2024-02-29T22:48:33Z",
+                "firstPatchedVersion": {
+                  "identifier": "9.3.1"
+                },
+                "vulnerableVersionRange": ">= 9.3.0, < 9.3.1",
+                "package": {
+                  "ecosystem": "GO",
+                  "name": "github.com/mattermost/mattermost/server/v8"
+                }
+              },
+              {
+                "severity": "MODERATE",
+                "updatedAt": "2024-02-29T22:48:33Z",
+                "firstPatchedVersion": {
+                  "identifier": "9.2.5"
+                },
+                "vulnerableVersionRange": ">= 9.2.0, < 9.2.5",
+                "package": {
+                  "ecosystem": "GO",
+                  "name": "github.com/mattermost/mattermost/server/v8"
+                }
+              }
+            ]
+          },
+          "classification": "GENERAL",
+          "cvssSeverities": {
+            "cvssV3": {
+              "score": 4.3,
+              "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:L"
+            },
+            "cvssV4": {
+              "score": 5.3,
+              "vectorString": "CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:N/VI:N/VA:L/SC:N/SI:N/SA:N"
+            }
+          },
+          "cwes": {
+            "edges": [
+              {
+                "cweId": "CWE-400",
+                "name": "Uncontrolled Resource Consumption",
+                "description": "The product does not properly control the allocation and maintenance of a limited resource, thereby enabling an actor to influence the amount of resources consumed, eventually leading to the exhaustion of available resources."
+              }
+            ]
+          },
+          "withdrawnAt": null
+        },
+        {
+          "databaseId": 275123,
+          "description": "An issue in the component src/api/identity.rs of Vaultwarden prior to v1.32.5 allows attackers to impersonate users, including Administrators, via a crafted authorization request.",
+          "ghsaId": "GHSA-x7m9-mv49-fv73",
+          "id": "GSA_kwCzR0hTQS14N205LW12NDktZnY3M84ABDKz",
+          "identifiers": [
+            {
+              "type": "GHSA",
+              "value": "GHSA-x7m9-mv49-fv73"
+            },
+            {
+              "type": "CVE",
+              "value": "CVE-2024-55225"
+            }
+          ],
+          "notificationsPermalink": "https://github.com/advisories/GHSA-x7m9-mv49-fv73/dependabot",
+          "origin": "UNSPECIFIED",
+          "permalink": "https://github.com/advisories/GHSA-x7m9-mv49-fv73",
+          "publishedAt": "2025-01-09T21:31:32Z",
+          "references": [
+            {
+              "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-55225"
+            },
+            {
+              "url": "https://github.com/dani-garcia/vaultwarden/releases/tag/1.32.4"
+            },
+            {
+              "url": "https://github.com/dani-garcia/vaultwarden/releases/tag/1.32.5"
+            },
+            {
+              "url": "https://insinuator.net/2024/11/vulnerability-disclosure-authentication-bypass-in-vaultwarden-versions-1-32-5"
+            },
+            {
+              "url": "https://github.com/dani-garcia/vaultwarden/commit/20d9e885bfcd7df7828d92c6e59ed5fe7b40a879"
+            },
+            {
+              "url": "https://github.com/dani-garcia/vaultwarden/commit/37c14c3c69b244ec50f5c62b4c9260171607c1d8"
+            },
+            {
+              "url": "https://github.com/advisories/GHSA-x7m9-mv49-fv73"
+            }
+          ],
+          "severity": "HIGH",
+          "summary": "Vaultwarden vulnerable to user impersonation",
+          "updatedAt": "2025-01-10T18:38:02Z",
+          "vulnerabilities": {
+            "edges": [
+              {
+                "severity": "HIGH",
+                "updatedAt": "2025-01-09T23:14:00Z",
+                "firstPatchedVersion": {
+                  "identifier": "1.32.5"
+                },
+                "vulnerableVersionRange": "< 1.32.5",
+                "package": {
+                  "ecosystem": "RUST",
+                  "name": "vaultwarden"
+                }
+              }
+            ]
+          },
+          "classification": "GENERAL",
+          "cvssSeverities": {
+            "cvssV3": {
+              "score": 0.0
+            },
+            "cvssV4": {
+              "score": 7.7,
+              "vectorString": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:H/VA:N/SC:N/SI:N/SA:N/E:P"
+            }
+          },
+          "cwes": {
+            "edges": [
+              {
+                "cweId": "CWE-276",
+                "name": "Incorrect Default Permissions",
+                "description": "During installation, installed file permissions are set to allow anyone to modify those files."
+              },
+              {
+                "cweId": "CWE-863",
+                "name": "Incorrect Authorization",
+                "description": "The product performs an authorization check when an actor attempts to access a resource or perform an action, but it does not correctly perform the check. This allows attackers to bypass intended access restrictions."
+              }
+            ]
+          },
+          "withdrawnAt": null
+        },
+        {
+          "databaseId": 268041,
+          "description": "Spring MVC controller methods with an @RequestBody byte[] method parameter are vulnerable to a DoS attack.",
+          "ghsaId": "GHSA-w3c8-7r8f-9jp8",
+          "id": "GSA_kwCzR0hTQS13M2M4LTdyOGYtOWpwOM4ABBcJ",
+          "identifiers": [
+            {
+              "type": "GHSA",
+              "value": "GHSA-w3c8-7r8f-9jp8"
+            },
+            {
+              "type": "CVE",
+              "value": "CVE-2024-38828"
+            }
+          ],
+          "notificationsPermalink": "https://github.com/advisories/GHSA-w3c8-7r8f-9jp8/dependabot",
+          "origin": "UNSPECIFIED",
+          "permalink": "https://github.com/advisories/GHSA-w3c8-7r8f-9jp8",
+          "publishedAt": "2024-11-18T06:30:35Z",
+          "references": [
+            {
+              "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-38828"
+            },
+            {
+              "url": "https://spring.io/security/cve-2024-38828"
+            },
+            {
+              "url": "https://github.com/advisories/GHSA-w3c8-7r8f-9jp8"
+            }
+          ],
+          "severity": "MODERATE",
+          "summary": "Spring MVC controller vulnerable to a DoS attack",
+          "updatedAt": "2025-01-11T00:19:21Z",
+          "vulnerabilities": {
+            "edges": [
+              {
+                "severity": "MODERATE",
+                "updatedAt": "2025-01-11T00:19:20Z",
+                "firstPatchedVersion": {
+                  "identifier": "5.3.42"
+                },
+                "vulnerableVersionRange": ">= 5.3.0, < 5.3.42",
+                "package": {
+                  "ecosystem": "MAVEN",
+                  "name": "org.springframework:spring-webmvc"
+                }
+              }
+            ]
+          },
+          "classification": "GENERAL",
+          "cvssSeverities": {
+            "cvssV3": {
+              "score": 5.3,
+              "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"
+            },
+            "cvssV4": {
+              "score": 0.0
+            }
+          },
+          "cwes": {
+            "edges": []
+          },
+          "withdrawnAt": null
+        },
+        {
+          "databaseId": 79143,
+          "description": "In Laravel Framework through 5.5.40 and 5.6.x through 5.6.29, remote code execution might occur as a result of an unserialize call on a potentially untrusted X-XSRF-TOKEN value. This involves the decrypt method in `Illuminate/Encryption/Encrypter.php` and PendingBroadcast in `gadgetchains/Laravel/RCE/3/chain.php` in phpggc. The attacker must know the application key, which normally would never occur, but could happen if the attacker previously had privileged access or successfully accomplished a previous attack.",
+          "ghsaId": "GHSA-qvqm-h22r-4cp9",
+          "id": "GSA_kwCzR0hTQS1xdnFtLWgyMnItNGNwOc4AATUn",
+          "identifiers": [
+            {
+              "type": "GHSA",
+              "value": "GHSA-qvqm-h22r-4cp9"
+            },
+            {
+              "type": "CVE",
+              "value": "CVE-2018-15133"
+            }
+          ],
+          "notificationsPermalink": "https://github.com/advisories/GHSA-qvqm-h22r-4cp9/dependabot",
+          "origin": "UNSPECIFIED",
+          "permalink": "https://github.com/advisories/GHSA-qvqm-h22r-4cp9",
+          "publishedAt": "2022-05-14T00:56:30Z",
+          "references": [
+            {
+              "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-15133"
+            },
+            {
+              "url": "https://laravel.com/docs/5.6/upgrade#upgrade-5.6.30"
+            },
+            {
+              "url": "http://packetstormsecurity.com/files/153641/PHP-Laravel-Framework-Token-Unserialize-Remote-Command-Execution.html"
+            },
+            {
+              "url": "https://github.com/laravel/framework/commit/d84cf988ed5d4661a4bf1fdcb08f5073835083a0"
+            },
+            {
+              "url": "https://github.com/kozmic/laravel-poc-CVE-2018-15133"
+            },
+            {
+              "url": "https://github.com/advisories/GHSA-qvqm-h22r-4cp9"
+            }
+          ],
+          "severity": "HIGH",
+          "summary": "Laravel Framework RCE Vulnerability",
+          "updatedAt": "2025-01-13T14:08:13Z",
+          "vulnerabilities": {
+            "edges": [
+              {
+                "severity": "HIGH",
+                "updatedAt": "2023-10-06T15:24:28Z",
+                "firstPatchedVersion": null,
+                "vulnerableVersionRange": "<= 5.5.40",
+                "package": {
+                  "ecosystem": "COMPOSER",
+                  "name": "laravel/framework"
+                }
+              },
+              {
+                "severity": "HIGH",
+                "updatedAt": "2025-01-13T14:08:13Z",
+                "firstPatchedVersion": {
+                  "identifier": "5.6.30"
+                },
+                "vulnerableVersionRange": ">= 5.6.0, <= 5.6.29",
+                "package": {
+                  "ecosystem": "COMPOSER",
+                  "name": "laravel/framework"
+                }
+              }
+            ]
+          },
+          "classification": "GENERAL",
+          "cvssSeverities": {
+            "cvssV3": {
+              "score": 8.1,
+              "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
+            },
+            "cvssV4": {
+              "score": 0.0
+            }
+          },
+          "cwes": {
+            "edges": [
+              {
+                "cweId": "CWE-502",
+                "name": "Deserialization of Untrusted Data",
+                "description": "The product deserializes untrusted data without sufficiently verifying that the resulting data will be valid."
+              }
+            ]
+          },
+          "withdrawnAt": null
+        },
+        {
+          "databaseId": 140333,
+          "description": "A double free vulnerability in the DDGifSlurp function in decoding.c in the android-gif-drawable library before version 1.2.18, as used in WhatsApp for Android before version 2.19.244 and many other Android applications, allows remote attackers to execute arbitrary code or cause a denial of service when the library is used to parse a specially crafted GIF image.",
+          "ghsaId": "GHSA-x534-j49x-mqvj",
+          "id": "GSA_kwCzR0hTQS14NTM0LWo0OXgtbXF2as4AAiQt",
+          "identifiers": [
+            {
+              "type": "GHSA",
+              "value": "GHSA-x534-j49x-mqvj"
+            },
+            {
+              "type": "CVE",
+              "value": "CVE-2019-11932"
+            }
+          ],
+          "notificationsPermalink": "https://github.com/advisories/GHSA-x534-j49x-mqvj/dependabot",
+          "origin": "UNSPECIFIED",
+          "permalink": "https://github.com/advisories/GHSA-x534-j49x-mqvj",
+          "publishedAt": "2022-05-24T16:57:50Z",
+          "references": [
+            {
+              "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-11932"
+            },
+            {
+              "url": "https://github.com/koral--/android-gif-drawable/pull/673"
+            },
+            {
+              "url": "https://github.com/koral--/android-gif-drawable/pull/673/commits/4944c92761e0a14f04868cbcf4f4e86fd4b7a4a9"
+            },
+            {
+              "url": "https://github.com/koral--/android-gif-drawable/commit/cc5b4f8e43463995a84efd594f89a21f906c2d20"
+            },
+            {
+              "url": "https://gist.github.com/wdormann/874198c1bd29c7dd2157d9fc1d858263"
+            },
+            {
+              "url": "https://www.facebook.com/security/advisories/cve-2019-11932"
+            },
+            {
+              "url": "http://packetstormsecurity.com/files/154867/Whatsapp-2.19.216-Remote-Code-Execution.html"
+            },
+            {
+              "url": "http://packetstormsecurity.com/files/158306/WhatsApp-android-gif-drawable-Double-Free.html"
+            },
+            {
+              "url": "http://seclists.org/fulldisclosure/2019/Nov/27"
+            },
+            {
+              "url": "https://awakened1712.github.io/hacking/hacking-whatsapp-gif-rce"
+            },
+            {
+              "url": "https://github.com/advisories/GHSA-x534-j49x-mqvj"
+            }
+          ],
+          "severity": "HIGH",
+          "summary": "android-gif-drawable Double Free vulnerability",
+          "updatedAt": "2025-01-13T15:21:41Z",
+          "vulnerabilities": {
+            "edges": [
+              {
+                "severity": "HIGH",
+                "updatedAt": "2025-01-13T15:21:41Z",
+                "firstPatchedVersion": {
+                  "identifier": "1.2.18"
+                },
+                "vulnerableVersionRange": "< 1.2.18",
+                "package": {
+                  "ecosystem": "MAVEN",
+                  "name": "pl.droidsonroids.gif:android-gif-drawable"
+                }
+              }
+            ]
+          },
+          "classification": "GENERAL",
+          "cvssSeverities": {
+            "cvssV3": {
+              "score": 8.8,
+              "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
+            },
+            "cvssV4": {
+              "score": 0.0
+            }
+          },
+          "cwes": {
+            "edges": [
+              {
+                "cweId": "CWE-415",
+                "name": "Double Free",
+                "description": "The product calls free() twice on the same memory address, potentially leading to modification of unexpected memory locations."
+              }
+            ]
+          },
+          "withdrawnAt": null
+        },
+        {
+          "databaseId": 9538,
+          "description": "decoding.c in android-gif-drawable before 1.2.24 does not limit the maximum length of a comment, leading to denial of service.",
+          "ghsaId": "GHSA-3mm4-w7v6-4rhv",
+          "id": "GSA_kwCzR0hTQS0zbW00LXc3djYtNHJods0lQg",
+          "identifiers": [
+            {
+              "type": "GHSA",
+              "value": "GHSA-3mm4-w7v6-4rhv"
+            },
+            {
+              "type": "CVE",
+              "value": "CVE-2022-23435"
+            }
+          ],
+          "notificationsPermalink": "https://github.com/advisories/GHSA-3mm4-w7v6-4rhv/dependabot",
+          "origin": "UNSPECIFIED",
+          "permalink": "https://github.com/advisories/GHSA-3mm4-w7v6-4rhv",
+          "publishedAt": "2022-01-20T00:01:54Z",
+          "references": [
+            {
+              "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-23435"
+            },
+            {
+              "url": "https://github.com/koral--/android-gif-drawable/commit/9f0f0c89e6fa38548163771feeb4bde84b828887"
+            },
+            {
+              "url": "https://github.com/koral--/android-gif-drawable/compare/v1.2.23...v1.2.24"
+            },
+            {
+              "url": "https://github.com/koral--/android-gif-drawable/issues/792#issuecomment-1048850678"
+            },
+            {
+              "url": "https://github.com/advisories/GHSA-3mm4-w7v6-4rhv"
+            }
+          ],
+          "severity": "HIGH",
+          "summary": "android-gif-drawable vulerable to denial of service due to unrestricted comment length",
+          "updatedAt": "2025-01-13T15:22:58Z",
+          "vulnerabilities": {
+            "edges": [
+              {
+                "severity": "HIGH",
+                "updatedAt": "2025-01-13T15:22:58Z",
+                "firstPatchedVersion": {
+                  "identifier": "1.2.24"
+                },
+                "vulnerableVersionRange": "< 1.2.24",
+                "package": {
+                  "ecosystem": "MAVEN",
+                  "name": "pl.droidsonroids.gif:android-gif-drawable"
+                }
+              }
+            ]
+          },
+          "classification": "GENERAL",
+          "cvssSeverities": {
+            "cvssV3": {
+              "score": 7.5,
+              "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+            },
+            "cvssV4": {
+              "score": 0.0
+            }
+          },
+          "cwes": {
+            "edges": [
+              {
+                "cweId": "CWE-770",
+                "name": "Allocation of Resources Without Limits or Throttling",
+                "description": "The product allocates a reusable resource or group of resources on behalf of an actor without imposing any restrictions on the size or number of resources that can be allocated, in violation of the intended security policy for that actor."
+              }
+            ]
+          },
+          "withdrawnAt": null
+        },
+        {
+          "databaseId": 275177,
+          "description": "Cross Site Scripting vulnerability in Microweber v.2.0.9 allows a remote attacker to execute arbitrary code via the campaign Name (Internal Name) field in the Add new campaign function",
+          "ghsaId": "GHSA-j4v9-cm37-h7c2",
+          "id": "GSA_kwCzR0hTQS1qNHY5LWNtMzctaDdjMs4ABDLp",
+          "identifiers": [
+            {
+              "type": "GHSA",
+              "value": "GHSA-j4v9-cm37-h7c2"
+            },
+            {
+              "type": "CVE",
+              "value": "CVE-2024-33297"
+            }
+          ],
+          "notificationsPermalink": "https://github.com/advisories/GHSA-j4v9-cm37-h7c2/dependabot",
+          "origin": "UNSPECIFIED",
+          "permalink": "https://github.com/advisories/GHSA-j4v9-cm37-h7c2",
+          "publishedAt": "2025-01-10T21:31:27Z",
+          "references": [
+            {
+              "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-33297"
+            },
+            {
+              "url": "https://github.com/MathSabo/CVE-2024-33297"
+            },
+            {
+              "url": "https://github.com/advisories/GHSA-j4v9-cm37-h7c2"
+            }
+          ],
+          "severity": "MODERATE",
+          "summary": "Microweber Cross-site Scripting vulnerability",
+          "updatedAt": "2025-01-13T15:23:13Z",
+          "vulnerabilities": {
+            "edges": [
+              {
+                "severity": "MODERATE",
+                "updatedAt": "2025-01-13T15:23:13Z",
+                "firstPatchedVersion": null,
+                "vulnerableVersionRange": "<= 2.0.9",
+                "package": {
+                  "ecosystem": "COMPOSER",
+                  "name": "microweber/microweber"
+                }
+              }
+            ]
+          },
+          "classification": "GENERAL",
+          "cvssSeverities": {
+            "cvssV3": {
+              "score": 0.0
+            },
+            "cvssV4": {
+              "score": 5.5,
+              "vectorString": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:N/SC:L/SI:L/SA:N/E:P"
+            }
+          },
+          "cwes": {
+            "edges": [
+              {
+                "cweId": "CWE-79",
+                "name": "Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')",
+                "description": "The product does not neutralize or incorrectly neutralizes user-controllable input before it is placed in output that is used as a web page that is served to other users."
+              }
+            ]
+          },
+          "withdrawnAt": null
+        },
+        {
+          "databaseId": 275182,
+          "description": "Microweber Cross Site Scripting vulnerability in Microweber v.2.0.9 allows a remote attacker to execute arbitrary code via the create new backup function in the endpoint /admin/module/view?type=admin__backup",
+          "ghsaId": "GHSA-w5g5-4jj3-8f6v",
+          "id": "GSA_kwCzR0hTQS13NWc1LTRqajMtOGY2ds4ABDLu",
+          "identifiers": [
+            {
+              "type": "GHSA",
+              "value": "GHSA-w5g5-4jj3-8f6v"
+            },
+            {
+              "type": "CVE",
+              "value": "CVE-2024-33298"
+            }
+          ],
+          "notificationsPermalink": "https://github.com/advisories/GHSA-w5g5-4jj3-8f6v/dependabot",
+          "origin": "UNSPECIFIED",
+          "permalink": "https://github.com/advisories/GHSA-w5g5-4jj3-8f6v",
+          "publishedAt": "2025-01-10T21:31:27Z",
+          "references": [
+            {
+              "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-33298"
+            },
+            {
+              "url": "https://github.com/MathSabo/CVE-2024-33298"
+            },
+            {
+              "url": "https://github.com/advisories/GHSA-w5g5-4jj3-8f6v"
+            }
+          ],
+          "severity": "MODERATE",
+          "summary": "Microweber Cross-site Scripting vulnerability",
+          "updatedAt": "2025-01-13T15:23:24Z",
+          "vulnerabilities": {
+            "edges": [
+              {
+                "severity": "MODERATE",
+                "updatedAt": "2025-01-13T15:23:24Z",
+                "firstPatchedVersion": null,
+                "vulnerableVersionRange": "<= 2.0.9",
+                "package": {
+                  "ecosystem": "COMPOSER",
+                  "name": "microweber/microweber"
+                }
+              }
+            ]
+          },
+          "classification": "GENERAL",
+          "cvssSeverities": {
+            "cvssV3": {
+              "score": 0.0
+            },
+            "cvssV4": {
+              "score": 5.5,
+              "vectorString": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:N/SC:L/SI:L/SA:N/E:P"
+            }
+          },
+          "cwes": {
+            "edges": [
+              {
+                "cweId": "CWE-79",
+                "name": "Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')",
+                "description": "The product does not neutralize or incorrectly neutralizes user-controllable input before it is placed in output that is used as a web page that is served to other users."
+              }
+            ]
+          },
+          "withdrawnAt": null
+        },
+        {
+          "databaseId": 275180,
+          "description": "Cross Site Scripting vulnerability in Microweber v.2.0.9 allows a remote attacker to execute arbitrary code via the First Name and Last Name parameters in the endpoint /admin/module/view?type=users",
+          "ghsaId": "GHSA-97h9-p9f8-4p3r",
+          "id": "GSA_kwCzR0hTQS05N2g5LXA5ZjgtNHAzcs4ABDLs",
+          "identifiers": [
+            {
+              "type": "GHSA",
+              "value": "GHSA-97h9-p9f8-4p3r"
+            },
+            {
+              "type": "CVE",
+              "value": "CVE-2024-33299"
+            }
+          ],
+          "notificationsPermalink": "https://github.com/advisories/GHSA-97h9-p9f8-4p3r/dependabot",
+          "origin": "UNSPECIFIED",
+          "permalink": "https://github.com/advisories/GHSA-97h9-p9f8-4p3r",
+          "publishedAt": "2025-01-10T21:31:27Z",
+          "references": [
+            {
+              "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-33299"
+            },
+            {
+              "url": "https://github.com/MathSabo/CVE-2024-33299"
+            },
+            {
+              "url": "https://github.com/advisories/GHSA-97h9-p9f8-4p3r"
+            }
+          ],
+          "severity": "MODERATE",
+          "summary": "Microweber Cross-site Scripting vulnerability",
+          "updatedAt": "2025-01-13T15:23:31Z",
+          "vulnerabilities": {
+            "edges": [
+              {
+                "severity": "MODERATE",
+                "updatedAt": "2025-01-13T15:23:31Z",
+                "firstPatchedVersion": null,
+                "vulnerableVersionRange": "<= 2.0.9",
+                "package": {
+                  "ecosystem": "COMPOSER",
+                  "name": "microweber/microweber"
+                }
+              }
+            ]
+          },
+          "classification": "GENERAL",
+          "cvssSeverities": {
+            "cvssV3": {
+              "score": 0.0
+            },
+            "cvssV4": {
+              "score": 5.5,
+              "vectorString": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:N/SC:L/SI:L/SA:N/E:P"
+            }
+          },
+          "cwes": {
+            "edges": [
+              {
+                "cweId": "CWE-79",
+                "name": "Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')",
+                "description": "The product does not neutralize or incorrectly neutralizes user-controllable input before it is placed in output that is used as a web page that is served to other users."
+              }
+            ]
+          },
+          "withdrawnAt": null
+        },
+        {
+          "databaseId": 211001,
+          "description": "In Moov signedxml through 1.0.0, parsing the raw XML (as received) can result in different output than parsing the canonicalized XML. Thus, signature validation can be bypassed via a Signature Wrapping attack (aka XSW).",
+          "ghsaId": "GHSA-jqvr-j2vg-gjrv",
+          "id": "GSA_kwCzR0hTQS1qcXZyLWoydmctZ2pyds4AAzg5",
+          "identifiers": [
+            {
+              "type": "GHSA",
+              "value": "GHSA-jqvr-j2vg-gjrv"
+            },
+            {
+              "type": "CVE",
+              "value": "CVE-2023-34205"
+            }
+          ],
+          "notificationsPermalink": "https://github.com/advisories/GHSA-jqvr-j2vg-gjrv/dependabot",
+          "origin": "UNSPECIFIED",
+          "permalink": "https://github.com/advisories/GHSA-jqvr-j2vg-gjrv",
+          "publishedAt": "2023-05-30T06:30:25Z",
+          "references": [
+            {
+              "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-34205"
+            },
+            {
+              "url": "https://github.com/moov-io/signedxml/issues/23"
+            },
+            {
+              "url": "https://github.com/moov-io/signedxml/pull/25"
+            },
+            {
+              "url": "https://github.com/moov-io/signedxml/releases/tag/v1.1.0"
+            },
+            {
+              "url": "https://pkg.go.dev/vuln/GO-2023-1826"
+            },
+            {
+              "url": "https://github.com/advisories/GHSA-jqvr-j2vg-gjrv"
             }
           ],
           "severity": "CRITICAL",
-          "summary": "Server secret was included in static assets and served to clients",
-          "updatedAt": "2023-01-06T05:01:57Z",
+          "summary": "Signature validation bypass in github.com/moov-io/signedxml",
+          "updatedAt": "2025-01-13T15:41:56Z",
           "vulnerabilities": {
             "edges": [
               {
-                "node": {
-                  "severity": "CRITICAL",
-                  "updatedAt": "2022-09-09T20:56:50Z",
-                  "firstPatchedVersion": {
-                    "identifier": "3.0.0"
-                  },
-                  "vulnerableVersionRange": ">= 2.0.0, < 3.0.0",
-                  "package": {
-                    "ecosystem": "NPM",
-                    "name": "flood"
-                  }
+                "severity": "CRITICAL",
+                "updatedAt": "2023-06-06T01:39:24Z",
+                "firstPatchedVersion": {
+                  "identifier": "1.1.0"
+                },
+                "vulnerableVersionRange": "< 1.1.0",
+                "package": {
+                  "ecosystem": "GO",
+                  "name": "github.com/moov-io/signedxml"
                 }
               }
-            ],
-            "totalCount": 1,
-            "pageInfo": {
-              "hasNextPage": false,
-              "hasPreviousPage": false,
-              "endCursor": "Y3Vyc29yOnYyOpK5MjAyMi0wOS0wOVQxNjo1Njo1MC0wNDowMM2Cyg==",
-              "startCursor": "Y3Vyc29yOnYyOpK5MjAyMi0wOS0wOVQxNjo1Njo1MC0wNDowMM2Cyg=="
-            }
+            ]
           },
-          "cvss": {
-            "score": 0,
-            "vectorString": null
+          "classification": "GENERAL",
+          "cvssSeverities": {
+            "cvssV3": {
+              "score": 9.1,
+              "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N"
+            },
+            "cvssV4": {
+              "score": 0.0
+            }
           },
           "cwes": {
-            "edges": [],
-            "totalCount": 0,
-            "pageInfo": {
-              "hasNextPage": false,
-              "hasPreviousPage": false
-            }
+            "edges": [
+              {
+                "cweId": "CWE-347",
+                "name": "Improper Verification of Cryptographic Signature",
+                "description": "The product does not verify, or incorrectly verifies, the cryptographic signature for data."
+              }
+            ]
           },
-          "withdrawnAt": null,
-          "classification": "GENERAL"
+          "withdrawnAt": null
         },
         {
-          "databaseId": 197913,
-          "description": "An issue was discovered in Keycloak when using a client with the `offline_access` scope. Reuse of session ids across root and user authentication sessions and a lack of root session validation enabled attackers to resolve a user session attached to a different previously authenticated user.\n\nThis issue most affects users of shared computers. Suppose a user logs out of their account (without clearing their cookies) in a mobile app or similar client that includes the `offline_access` scope, and another user authenticates to the application. In that case, it will share the same root session id, and when utilizing the refresh token, they will be issued a token for the original user.",
-          "ghsaId": "GHSA-97g8-xfvw-q4hg",
-          "id": "GSA_kwCzR0hTQS05N2c4LXhmdnctcTRoZ84AAwUZ",
+          "databaseId": 275371,
+          "description": "### Summary\nThe issue was identified during Quarkslab's security audit on the Certificate Revocation List (CRL) based revocation check feature.\nAfter retrieving the CRL, notation-go attempts to update the CRL cache using the os.Rename method. However, this operation may fail due to operating system-specific limitations, particularly when the source and destination paths are on different mount points. This failure could lead to an unexpected program termination.\n\n### Details\n\nIn method `crl.(*FileCache).Set`, a temporary file is created in the OS dedicated area (like /tmp for, usually, Linux/Unix). The file is written and then it is tried to move it to the dedicated `notation` cache directory thanks `os.Rename`. As specified in Go documentation, OS specific restriction may apply. When used with Linux OS, it is relying on `rename` syscall from the libc and as per the [documentation](https://man7.org/linux/man-pages/man2/rename.2.html), moving a file to a different mountpoint raises an `EXDEV` error, interpreted as `Cross device link not permitted error`.\nSome Linux distribution, like `RedHat` use a dedicated filesystem (`tmpfs`), mounted on a specific mountpoint (usually `/tmp`) for temporary files. When using such OS, revocation check based on CRL will repeatedly crash `notation`. \n\n### PoC\n1. Ensure that the temporary file storage area (e.g., /tmp) is mounted on a different mount point than the user's 'notation' cache directory.\n2. Either disable the Online Certificate Status Protocol (OCSP) revocation check, or utilize certificates that exclusively support Certificate Revocation Lists (CRLs) for revocation check.\n3. Try to verify a previously generated signature using the 'notation' tool.\n\n### Impact\nThe signature verification process is aborted as process crashes.\n\n### Remediation\nThe cache file should be created, written, then copied to the wanted final location, and finally removed. Additionally, this error shouldn't lead to a crash as it is not fatal and shouldn't prevent the rest of the program to properly continue\n",
+          "ghsaId": "GHSA-qjh3-4j3h-vmwp",
+          "id": "GSA_kwCzR0hTQS1xamgzLTRqM2gtdm13cM4ABDOr",
           "identifiers": [
             {
               "type": "GHSA",
-              "value": "GHSA-97g8-xfvw-q4hg"
+              "value": "GHSA-qjh3-4j3h-vmwp"
             },
             {
               "type": "CVE",
-              "value": "CVE-2022-3916"
+              "value": "CVE-2024-51491"
             }
           ],
-          "notificationsPermalink": "https://github.com/advisories/GHSA-97g8-xfvw-q4hg/dependabot",
+          "notificationsPermalink": "https://github.com/advisories/GHSA-qjh3-4j3h-vmwp/dependabot",
           "origin": "UNSPECIFIED",
-          "permalink": "https://github.com/advisories/GHSA-97g8-xfvw-q4hg",
-          "publishedAt": "2022-12-13T19:44:33Z",
+          "permalink": "https://github.com/advisories/GHSA-qjh3-4j3h-vmwp",
+          "publishedAt": "2025-01-13T16:13:59Z",
           "references": [
             {
-              "url": "https://github.com/keycloak/keycloak/security/advisories/GHSA-97g8-xfvw-q4hg"
+              "url": "https://github.com/notaryproject/notation-go/security/advisories/GHSA-qjh3-4j3h-vmwp"
             },
             {
-              "url": "https://github.com/advisories/GHSA-97g8-xfvw-q4hg"
+              "url": "https://github.com/notaryproject/notation-go/commit/3c3302258ad510fbca2f8a73731569d91f07d196"
+            },
+            {
+              "url": "https://github.com/advisories/GHSA-qjh3-4j3h-vmwp"
             }
           ],
-          "severity": "MODERATE",
-          "summary": "Keycloak vulnerable to session takeover with OIDC offline refreshtokens",
-          "updatedAt": "2023-01-06T05:04:41Z",
+          "severity": "LOW",
+          "summary": "notation-go has an OS error when setting CRL cache leads to denial of signature verification",
+          "updatedAt": "2025-01-13T16:14:03Z",
           "vulnerabilities": {
             "edges": [
               {
-                "node": {
-                  "severity": "MODERATE",
-                  "updatedAt": "2022-12-13T19:44:33Z",
-                  "firstPatchedVersion": {
-                    "identifier": "20.0.2"
-                  },
-                  "vulnerableVersionRange": "<= 19.0.2",
-                  "package": {
-                    "ecosystem": "MAVEN",
-                    "name": "org.keycloak:keycloak-parent"
-                  }
+                "severity": "LOW",
+                "updatedAt": "2025-01-13T16:14:03Z",
+                "firstPatchedVersion": {
+                  "identifier": "1.3.0-rc.2"
+                },
+                "vulnerableVersionRange": "= 1.3.0-rc.1",
+                "package": {
+                  "ecosystem": "GO",
+                  "name": "github.com/notaryproject/notation-go"
                 }
               }
-            ],
-            "totalCount": 1,
-            "pageInfo": {
-              "hasNextPage": false,
-              "hasPreviousPage": false,
-              "endCursor": "Y3Vyc29yOnYyOpK5MjAyMi0xMi0xM1QxNDo0NDozMy0wNTowMM2RQQ==",
-              "startCursor": "Y3Vyc29yOnYyOpK5MjAyMi0xMi0xM1QxNDo0NDozMy0wNTowMM2RQQ=="
-            }
+            ]
           },
-          "cvss": {
-            "score": 0,
-            "vectorString": null
+          "classification": "GENERAL",
+          "cvssSeverities": {
+            "cvssV3": {
+              "score": 3.3,
+              "vectorString": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:L"
+            },
+            "cvssV4": {
+              "score": 0.0
+            }
           },
           "cwes": {
             "edges": [
               {
-                "node": {
-                  "cweId": "CWE-287",
-                  "name": "Improper Authentication",
-                  "description": "When an actor claims to have a given identity, the software does not prove or insufficiently proves that the claim is correct."
-                }
-              },
-              {
-                "node": {
-                  "cweId": "CWE-304",
-                  "name": "Missing Critical Step in Authentication",
-                  "description": "The software implements an authentication technique, but it skips a step that weakens the technique."
-                }
-              },
-              {
-                "node": {
-                  "cweId": "CWE-488",
-                  "name": "Exposure of Data Element to Wrong Session",
-                  "description": "The product does not sufficiently enforce boundaries between the states of different sessions, causing data to be provided to, or used by, the wrong session."
-                }
+                "cweId": "CWE-703",
+                "name": "Improper Check or Handling of Exceptional Conditions",
+                "description": "The product does not properly anticipate or handle exceptional conditions that rarely occur during normal operation of the product."
               }
-            ],
-            "totalCount": 3,
-            "pageInfo": {
-              "hasNextPage": false,
-              "hasPreviousPage": false
-            }
+            ]
           },
-          "withdrawnAt": null,
-          "classification": "GENERAL"
+          "withdrawnAt": null
         },
         {
-          "databaseId": 179004,
-          "description": "`tower_http::services::fs::ServeDir` didn't correctly validate Windows paths\nmeaning paths like `/foo/bar/c:/windows/web/screen/img101.png` would be allowed\nand respond with the contents of `c:/windows/web/screen/img101.png`. Thus users\ncould potentially read files anywhere on the filesystem.\n\nThis only impacts Windows. Linux and other unix likes are not impacted by this.\n\nSee [tower-http#204] for more details.\n\n[tower-http#204]: https://github.com/tower-rs/tower-http/pull/204\n",
-          "ghsaId": "GHSA-wwh2-r387-g5rm",
-          "id": "GSA_kwCzR0hTQS13d2gyLXIzODctZzVybc4AArs8",
+          "databaseId": 275372,
+          "description": "This issue was identified during Quarkslab's audit of the timestamp feature.\n\n### Summary\nDuring the timestamp signature generation, the revocation status of the certificate(s) used to generate the timestamp signature was not verified.\n\n### Details\nDuring timestamp signature generation, notation-go did not check the revocation status of the certificate chain used by the TSA. This oversight creates a vulnerability that could be exploited through a Man-in-The-Middle attack. An attacker could potentially use a compromised, intermediate, or revoked leaf certificate to generate a malicious countersignature, which would then be accepted and stored by `notation`.\n\n### Impact\nThis could lead to denial of service scenarios, particularly in CI/CD environments during signature verification processes because timestamp signature would fail due to the presence of a revoked certificate(s) potentially disrupting operations.\n",
+          "ghsaId": "GHSA-45v3-38pc-874v",
+          "id": "GSA_kwCzR0hTQS00NXYzLTM4cGMtODc0ds4ABDOs",
           "identifiers": [
             {
               "type": "GHSA",
-              "value": "GHSA-wwh2-r387-g5rm"
-            }
-          ],
-          "notificationsPermalink": "https://github.com/advisories/GHSA-wwh2-r387-g5rm/dependabot",
-          "origin": "UNSPECIFIED",
-          "permalink": "https://github.com/advisories/GHSA-wwh2-r387-g5rm",
-          "publishedAt": "2022-06-17T00:26:05Z",
-          "references": [
-            {
-              "url": "https://github.com/tower-rs/tower-http/pull/204"
-            },
-            {
-              "url": "https://rustsec.org/advisories/RUSTSEC-2021-0135.html"
-            },
-            {
-              "url": "https://github.com/advisories/GHSA-wwh2-r387-g5rm"
-            }
-          ],
-          "severity": "MODERATE",
-          "summary": "tower-http's improper validation of Windows paths could lead to directory traversal attack",
-          "updatedAt": "2023-01-06T05:05:53Z",
-          "vulnerabilities": {
-            "edges": [
-              {
-                "node": {
-                  "severity": "MODERATE",
-                  "updatedAt": "2022-06-17T00:26:05Z",
-                  "firstPatchedVersion": {
-                    "identifier": "0.2.1"
-                  },
-                  "vulnerableVersionRange": ">= 0.2.0, < 0.2.1",
-                  "package": {
-                    "ecosystem": "RUST",
-                    "name": "tower-http"
-                  }
-                }
-              },
-              {
-                "node": {
-                  "severity": "MODERATE",
-                  "updatedAt": "2022-06-17T00:26:05Z",
-                  "firstPatchedVersion": {
-                    "identifier": "0.1.3"
-                  },
-                  "vulnerableVersionRange": "< 0.1.3",
-                  "package": {
-                    "ecosystem": "RUST",
-                    "name": "tower-http"
-                  }
-                }
-              }
-            ],
-            "totalCount": 2,
-            "pageInfo": {
-              "hasNextPage": false,
-              "hasPreviousPage": false,
-              "endCursor": "Y3Vyc29yOnYyOpK5MjAyMi0wNi0xNlQyMDoyNjowNS0wNDowMM1ftw==",
-              "startCursor": "Y3Vyc29yOnYyOpK5MjAyMi0wNi0xNlQyMDoyNjowNS0wNDowMM1ftg=="
-            }
-          },
-          "cvss": {
-            "score": 0,
-            "vectorString": null
-          },
-          "cwes": {
-            "edges": [
-              {
-                "node": {
-                  "cweId": "CWE-22",
-                  "name": "Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')",
-                  "description": "The software uses external input to construct a pathname that is intended to identify a file or directory that is located underneath a restricted parent directory, but the software does not properly neutralize special elements within the pathname that can cause the pathname to resolve to a location that is outside of the restricted directory."
-                }
-              }
-            ],
-            "totalCount": 1,
-            "pageInfo": {
-              "hasNextPage": false,
-              "hasPreviousPage": false
-            }
-          },
-          "withdrawnAt": null,
-          "classification": "GENERAL"
-        },
-        {
-          "databaseId": 185990,
-          "description": "Versions of `distributed` earlier than `2021.10.0` had a potential security vulnerability relating to single-machine Dask clusters.\n\nClusters started with `dask.distributed.LocalCluster` or `dask.distributed.Client()` (which defaults to using `LocalCluster`) would mistakenly configure their respective Dask workers to listen on external interfaces (typically with a randomly selected high port) rather than only on `localhost`. A Dask cluster created using this method AND running on a machine that has these ports exposed could be used by a sophisticated attacker to enable remote code execution. Users running on machines with standard firewalls in place, or using clusters created via cluster objects other than `LocalCluster` (e.g. `dask_kubernetes.KubeCluster`) should not be affected. This vulnerability is documented in CVE-2021-42343, and was fixed in version `2021.10.0` (PR #5427).",
-          "ghsaId": "GHSA-hwqr-f3v9-hwxr",
-          "id": "GSA_kwCzR0hTQS1od3FyLWYzdjktaHd4cs4AAtaG",
-          "identifiers": [
-            {
-              "type": "GHSA",
-              "value": "GHSA-hwqr-f3v9-hwxr"
-            }
-          ],
-          "notificationsPermalink": "https://github.com/advisories/GHSA-hwqr-f3v9-hwxr/dependabot",
-          "origin": "UNSPECIFIED",
-          "permalink": "https://github.com/advisories/GHSA-hwqr-f3v9-hwxr",
-          "publishedAt": "2022-07-15T21:56:08Z",
-          "references": [
-            {
-              "url": "https://github.com/dask/distributed/security/advisories/GHSA-hwqr-f3v9-hwxr"
-            },
-            {
-              "url": "https://docs.dask.org/en/latest/changelog.html"
-            },
-            {
-              "url": "https://github.com/dask/dask/tags"
-            },
-            {
-              "url": "https://github.com/pypa/advisory-database/tree/main/vulns/distributed/PYSEC-2021-871.yaml"
-            },
-            {
-              "url": "https://github.com/pypa/advisory-database/tree/main/vulns/distributed/PYSEC-2021-872.yaml"
-            },
-            {
-              "url": "https://github.com/advisories/GHSA-j8fq-86c5-5v2r"
-            },
-            {
-              "url": "https://github.com/advisories/GHSA-hwqr-f3v9-hwxr"
-            }
-          ],
-          "severity": "MODERATE",
-          "summary": "Workers for local Dask clusters mistakenly listened on public interfaces",
-          "updatedAt": "2023-01-06T05:05:59Z",
-          "vulnerabilities": {
-            "edges": [
-              {
-                "node": {
-                  "severity": "MODERATE",
-                  "updatedAt": "2022-07-15T21:56:09Z",
-                  "firstPatchedVersion": {
-                    "identifier": "2021.10.0"
-                  },
-                  "vulnerableVersionRange": ">= 0, < 2021.10.0",
-                  "package": {
-                    "ecosystem": "PIP",
-                    "name": "distributed"
-                  }
-                }
-              }
-            ],
-            "totalCount": 1,
-            "pageInfo": {
-              "hasNextPage": false,
-              "hasPreviousPage": false,
-              "endCursor": "Y3Vyc29yOnYyOpK5MjAyMi0wNy0xNVQxNzo1NjowOS0wNDowMM16gw==",
-              "startCursor": "Y3Vyc29yOnYyOpK5MjAyMi0wNy0xNVQxNzo1NjowOS0wNDowMM16gw=="
-            }
-          },
-          "cvss": {
-            "score": 0,
-            "vectorString": null
-          },
-          "cwes": {
-            "edges": [],
-            "totalCount": 0,
-            "pageInfo": {
-              "hasNextPage": false,
-              "hasPreviousPage": false
-            }
-          },
-          "withdrawnAt": null,
-          "classification": "GENERAL"
-        },
-        {
-          "databaseId": 191238,
-          "description": "### Impact\nHarbor fails to validate the user permissions when reading job execution logs through the P2P preheat execution logs - API call\n\n  GET /projects/{project_name}/preheat/policies/{preheat_policy_name}/executions/{execution_id}/tasks/{task_id}/logs\n\nBy sending a request that attempts to read P2P preheat execution logs and specifying different job ids, malicious authenticatedusers could read all the job logs stored in the Harbor database.\n\n### Patches\nThis and similar issues are fixed in Harbor v2.5.2 and later. Please upgrade as soon as possible.\n\n### Workarounds\nThere are no workarounds available.\n\n### For more information\nIf you have any questions or comments about this advisory:\n* Open an issue in [the Harbor GitHub repository](https://github.com/goharbor/harbor)\n\n### Credits\nThanks to [Gal Goldstein](https://www.linkedin.com/in/gal-goldshtein/) and [Daniel Abeles](https://www.linkedin.com/in/daniel-abeles/) from [Oxeye Security](https://www.oxeye.io/) for reporting this issue.\n",
-          "ghsaId": "GHSA-q76q-q8hw-hmpw",
-          "id": "GSA_kwCzR0hTQS1xNzZxLXE4aHctaG1wd84AAusG",
-          "identifiers": [
-            {
-              "type": "GHSA",
-              "value": "GHSA-q76q-q8hw-hmpw"
+              "value": "GHSA-45v3-38pc-874v"
             },
             {
               "type": "CVE",
-              "value": "CVE-2022-31671"
+              "value": "CVE-2024-56138"
             }
           ],
-          "notificationsPermalink": "https://github.com/advisories/GHSA-q76q-q8hw-hmpw/dependabot",
+          "notificationsPermalink": "https://github.com/advisories/GHSA-45v3-38pc-874v/dependabot",
           "origin": "UNSPECIFIED",
-          "permalink": "https://github.com/advisories/GHSA-q76q-q8hw-hmpw",
-          "publishedAt": "2022-09-09T19:47:03Z",
+          "permalink": "https://github.com/advisories/GHSA-45v3-38pc-874v",
+          "publishedAt": "2025-01-13T16:14:07Z",
           "references": [
             {
-              "url": "https://github.com/goharbor/harbor/security/advisories/GHSA-q76q-q8hw-hmpw"
+              "url": "https://github.com/notaryproject/notation-go/security/advisories/GHSA-45v3-38pc-874v"
             },
             {
-              "url": "https://github.com/advisories/GHSA-q76q-q8hw-hmpw"
+              "url": "https://github.com/notaryproject/notation-go/commit/e99be1954a15673020150c5f8800b8174cd7428d"
+            },
+            {
+              "url": "https://github.com/advisories/GHSA-45v3-38pc-874v"
             }
           ],
           "severity": "MODERATE",
-          "summary": "Harbor fails to validate the user permissions when reading job execution logs through the P2P preheat execution logs",
-          "updatedAt": "2023-01-06T05:06:01Z",
+          "summary": "notation-go's timestamp signature generation lacks certificate revocation check",
+          "updatedAt": "2025-01-13T16:14:08Z",
           "vulnerabilities": {
             "edges": [
               {
-                "node": {
-                  "severity": "MODERATE",
-                  "updatedAt": "2022-09-09T19:47:03Z",
-                  "firstPatchedVersion": {
-                    "identifier": "1.10.13"
-                  },
-                  "vulnerableVersionRange": ">= 1.0, <= 1.10.12",
-                  "package": {
-                    "ecosystem": "GO",
-                    "name": "github.com/goharbor/harbor"
-                  }
-                }
-              },
-              {
-                "node": {
-                  "severity": "MODERATE",
-                  "updatedAt": "2022-09-09T19:47:03Z",
-                  "firstPatchedVersion": {
-                    "identifier": "2.4.3"
-                  },
-                  "vulnerableVersionRange": ">= 2.0, <= 2.4.2",
-                  "package": {
-                    "ecosystem": "GO",
-                    "name": "github.com/goharbor/harbor"
-                  }
-                }
-              },
-              {
-                "node": {
-                  "severity": "MODERATE",
-                  "updatedAt": "2022-09-09T19:47:03Z",
-                  "firstPatchedVersion": {
-                    "identifier": "2.5.2"
-                  },
-                  "vulnerableVersionRange": ">= 2.5, <= 2.5.1",
-                  "package": {
-                    "ecosystem": "GO",
-                    "name": "github.com/goharbor/harbor"
-                  }
+                "severity": "MODERATE",
+                "updatedAt": "2025-01-13T16:14:08Z",
+                "firstPatchedVersion": {
+                  "identifier": "1.3.0-rc.2"
+                },
+                "vulnerableVersionRange": ">= 1.2.0-beta.1, <= 1.3.0-rc.1",
+                "package": {
+                  "ecosystem": "GO",
+                  "name": "github.com/notaryproject/notation-go"
                 }
               }
-            ],
-            "totalCount": 3,
-            "pageInfo": {
-              "hasNextPage": false,
-              "hasPreviousPage": false,
-              "endCursor": "Y3Vyc29yOnYyOpK5MjAyMi0wOS0wOVQxNTo0NzowMy0wNDowMM2Cxw==",
-              "startCursor": "Y3Vyc29yOnYyOpK5MjAyMi0wOS0wOVQxNTo0NzowMy0wNDowMM2CxQ=="
-            }
+            ]
           },
-          "cvss": {
-            "score": 5,
-            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:L/I:N/A:N"
+          "classification": "GENERAL",
+          "cvssSeverities": {
+            "cvssV3": {
+              "score": 4.0,
+              "vectorString": "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"
+            },
+            "cvssV4": {
+              "score": 0.0
+            }
           },
           "cwes": {
-            "edges": [],
-            "totalCount": 0,
-            "pageInfo": {
-              "hasNextPage": false,
-              "hasPreviousPage": false
-            }
+            "edges": [
+              {
+                "cweId": "CWE-299",
+                "name": "Improper Check for Certificate Revocation",
+                "description": "The product does not check or incorrectly checks the revocation status of a certificate, which may cause it to use a certificate that has been compromised."
+              }
+            ]
           },
-          "withdrawnAt": null,
-          "classification": "GENERAL"
+          "withdrawnAt": null
         },
         {
-          "databaseId": 195572,
-          "description": "The compression and decompression function used `mem:uninitialized` to create an array of uninitialized values, to later write values into it. This later leads to reads from uninitialized memory.\n\nThe flaw was corrected in commit b633bf265e41c60dfce3be7eac4e4dd5e18d06cf by using a heap-allocated `Vec` and removing out use of `mem::uninitialized`. The fix was released in v0.3.2 and v1.0.0\n\nSubsequently, the crate was deprecated and its use is discouraged.\n",
-          "ghsaId": "GHSA-5m39-wx2q-mxg3",
-          "id": "GSA_kwCzR0hTQS01bTM5LXd4MnEtbXhnM84AAvv0",
+          "databaseId": 275373,
+          "description": "### Impact\nThe Heartcore headless client library depends on [Refit ](https://github.com/reactiveui/refit) to assist in making HTTP requests to Heartcore public APIs. Refit recently published an advisory regarding a CRLF injection vulnerability whereby it is possible for a malicious user to smuggle additional headers or potentially body content into a request.\n\nThis shouldn't affect Heartcore client library usage as the vulnerable method - `HttpHeaders.TryAddWithoutValidation` - is not used. However, since Refit is a transient dependency for applications using this library, then any users making direct use of Refit could be vulnerable.\n\n### Patches\nThe vulnerable version of Refit has been upgraded to a secure version, as of Umbraco.Headless.Client.Net version 1.5.0, available on [Nuget](https://www.nuget.org/packages/Umbraco.Headless.Client.Net/1.5.0).\n\n### Workarounds\nIf calling Refit from your own code, set any necessary HTTP headers without use of `HttpHeaders.TryAddWithoutValidation`.\n\n### References\nSee the [original Refit advisory](https://github.com/reactiveui/refit/security/advisories/GHSA-3hxg-fxwm-8gf7) for further info.\n",
+          "ghsaId": "GHSA-mgr7-5782-6jh9",
+          "id": "GSA_kwCzR0hTQS1tZ3I3LTU3ODItNmpoOc4ABDOt",
           "identifiers": [
             {
               "type": "GHSA",
-              "value": "GHSA-5m39-wx2q-mxg3"
+              "value": "GHSA-mgr7-5782-6jh9"
             }
           ],
-          "notificationsPermalink": "https://github.com/advisories/GHSA-5m39-wx2q-mxg3/dependabot",
+          "notificationsPermalink": "https://github.com/advisories/GHSA-mgr7-5782-6jh9/dependabot",
           "origin": "UNSPECIFIED",
-          "permalink": "https://github.com/advisories/GHSA-5m39-wx2q-mxg3",
-          "publishedAt": "2022-11-08T21:42:06Z",
+          "permalink": "https://github.com/advisories/GHSA-mgr7-5782-6jh9",
+          "publishedAt": "2025-01-13T16:18:39Z",
           "references": [
             {
-              "url": "https://github.com/badboy/lzf-rs/issues/9"
+              "url": "https://github.com/reactiveui/refit/security/advisories/GHSA-3hxg-fxwm-8gf7"
             },
             {
-              "url": "https://github.com/badboy/lzf-rs/commit/b633bf265e41c60dfce3be7eac4e4dd5e18d06cf"
+              "url": "https://github.com/umbraco/Umbraco.Headless.Client.Net/security/advisories/GHSA-mgr7-5782-6jh9"
             },
             {
-              "url": "https://rustsec.org/advisories/RUSTSEC-2022-0067.html"
+              "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-51501"
             },
             {
-              "url": "https://github.com/advisories/GHSA-5m39-wx2q-mxg3"
+              "url": "https://github.com/advisories/GHSA-mgr7-5782-6jh9"
             }
           ],
-          "severity": "MODERATE",
-          "summary": "Invalid use of `mem::uninitialized` causes `use-of-uninitialized-value`",
-          "updatedAt": "2023-01-06T05:06:20Z",
+          "severity": "LOW",
+          "summary": "The Umbraco Heartcore headless client library uses a vulnerable Refit dependency package",
+          "updatedAt": "2025-01-13T16:18:40Z",
           "vulnerabilities": {
             "edges": [
               {
-                "node": {
-                  "severity": "MODERATE",
-                  "updatedAt": "2022-11-08T21:42:06Z",
-                  "firstPatchedVersion": {
-                    "identifier": "0.3.2"
-                  },
-                  "vulnerableVersionRange": "< 0.3.2",
-                  "package": {
-                    "ecosystem": "RUST",
-                    "name": "lzf"
-                  }
+                "severity": "LOW",
+                "updatedAt": "2025-01-13T16:18:40Z",
+                "firstPatchedVersion": {
+                  "identifier": "1.5.0"
+                },
+                "vulnerableVersionRange": "<= 1.4.1",
+                "package": {
+                  "ecosystem": "NUGET",
+                  "name": "Umbraco.Headless.Client.Net"
                 }
               }
-            ],
-            "totalCount": 1,
-            "pageInfo": {
-              "hasNextPage": false,
-              "hasPreviousPage": false,
-              "endCursor": "Y3Vyc29yOnYyOpK5MjAyMi0xMS0wOFQxNjo0MjowNi0wNTowMM2MvA==",
-              "startCursor": "Y3Vyc29yOnYyOpK5MjAyMi0xMS0wOFQxNjo0MjowNi0wNTowMM2MvA=="
-            }
+            ]
           },
-          "cvss": {
-            "score": 0,
-            "vectorString": null
+          "classification": "GENERAL",
+          "cvssSeverities": {
+            "cvssV3": {
+              "score": 0.0
+            },
+            "cvssV4": {
+              "score": 0.0
+            }
           },
           "cwes": {
-            "edges": [],
-            "totalCount": 0,
-            "pageInfo": {
-              "hasNextPage": false,
-              "hasPreviousPage": false
-            }
+            "edges": [
+              {
+                "cweId": "CWE-93",
+                "name": "Improper Neutralization of CRLF Sequences ('CRLF Injection')",
+                "description": "The product uses CRLF (carriage return line feeds) as a special element, e.g. to separate lines or records, but it does not neutralize or incorrectly neutralizes CRLF sequences from inputs."
+              },
+              {
+                "cweId": "CWE-1395",
+                "name": "Dependency on Vulnerable Third-Party Component",
+                "description": "The product has a dependency on a third-party component that contains one or more known vulnerabilities."
+              }
+            ]
           },
-          "withdrawnAt": null,
-          "classification": "GENERAL"
+          "withdrawnAt": null
         },
         {
-          "databaseId": 994,
-          "description": "An issue was discovered in YMFE YApi 1.3.23. There is stored XSS in the name field of a project.",
-          "ghsaId": "GHSA-5xgh-643p-cp2g",
-          "id": "MDE2OlNlY3VyaXR5QWR2aXNvcnlHSFNBLTV4Z2gtNjQzcC1jcDJn",
+          "databaseId": 275376,
+          "description": "A potential Denial of Service (DoS) vulnerability has been identified in Keycloak, which could allow an administrative user with the rights to change realm settings to disrupt the service. This is done by modifying any of the security headers and inserting newlines, which causes the Keycloak server to write to a request that is already terminated, leading to a failure of said request.\n\nService disruption may happen, users will be unable to access applications relying on Keycloak, or any of the consoles provided by Keycloak itself on the affected realm.",
+          "ghsaId": "GHSA-w3g8-r9gw-qrh8",
+          "id": "GSA_kwCzR0hTQS13M2c4LXI5Z3ctcXJoOM4ABDOw",
           "identifiers": [
             {
               "type": "GHSA",
-              "value": "GHSA-5xgh-643p-cp2g"
+              "value": "GHSA-w3g8-r9gw-qrh8"
             },
             {
               "type": "CVE",
-              "value": "CVE-2018-17574"
+              "value": "CVE-2024-11734"
             }
           ],
-          "notificationsPermalink": "https://github.com/advisories/GHSA-5xgh-643p-cp2g/dependabot",
+          "notificationsPermalink": "https://github.com/advisories/GHSA-w3g8-r9gw-qrh8/dependabot",
           "origin": "UNSPECIFIED",
-          "permalink": "https://github.com/advisories/GHSA-5xgh-643p-cp2g",
-          "publishedAt": "2018-11-21T22:19:59Z",
+          "permalink": "https://github.com/advisories/GHSA-w3g8-r9gw-qrh8",
+          "publishedAt": "2025-01-13T16:58:23Z",
           "references": [
             {
-              "url": "https://nvd.nist.gov/vuln/detail/CVE-2018-17574"
+              "url": "https://github.com/keycloak/keycloak/security/advisories/GHSA-w3g8-r9gw-qrh8"
             },
             {
-              "url": "https://github.com/YMFE/yapi/issues/520"
+              "url": "https://github.com/keycloak/keycloak/commit/93b2a7327b2557eb132a8169086c5e63c81dff79"
             },
             {
-              "url": "https://github.com/advisories/GHSA-5xgh-643p-cp2g"
+              "url": "https://github.com/advisories/GHSA-w3g8-r9gw-qrh8"
             }
           ],
           "severity": "MODERATE",
-          "summary": "Cross-site Scripting in yapi-vendor",
-          "updatedAt": "2023-01-06T05:06:58Z",
+          "summary": "Denial of Service in Keycloak Server via Security Headers",
+          "updatedAt": "2025-01-13T16:58:25Z",
           "vulnerabilities": {
             "edges": [
               {
-                "node": {
-                  "severity": "MODERATE",
-                  "updatedAt": "2018-11-21T22:16:17Z",
-                  "firstPatchedVersion": {
-                    "identifier": "1.3.23"
-                  },
-                  "vulnerableVersionRange": "< 1.3.23",
-                  "package": {
-                    "ecosystem": "NPM",
-                    "name": "yapi-vendor"
-                  }
+                "severity": "MODERATE",
+                "updatedAt": "2025-01-13T16:58:25Z",
+                "firstPatchedVersion": {
+                  "identifier": "26.0.8"
+                },
+                "vulnerableVersionRange": "< 26.0.8",
+                "package": {
+                  "ecosystem": "MAVEN",
+                  "name": "org.keycloak:keycloak-quarkus-server"
                 }
               }
-            ],
-            "totalCount": 1,
-            "pageInfo": {
-              "hasNextPage": false,
-              "hasPreviousPage": false,
-              "endCursor": "Y3Vyc29yOnYyOpK5MjAxOC0xMS0yMVQxNzoxNjoxNy0wNTowMM0GcQ==",
-              "startCursor": "Y3Vyc29yOnYyOpK5MjAxOC0xMS0yMVQxNzoxNjoxNy0wNTowMM0GcQ=="
-            }
+            ]
           },
-          "cvss": {
-            "score": 5.4,
-            "vectorString": "CVSS:3.0/AV:N/AC:L/PR:L/UI:R/S:C/C:L/I:L/A:N"
+          "classification": "GENERAL",
+          "cvssSeverities": {
+            "cvssV3": {
+              "score": 6.5,
+              "vectorString": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H"
+            },
+            "cvssV4": {
+              "score": 0.0
+            }
           },
           "cwes": {
             "edges": [
               {
-                "node": {
-                  "cweId": "CWE-79",
-                  "name": "Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')",
-                  "description": "The software does not neutralize or incorrectly neutralizes user-controllable input before it is placed in output that is used as a web page that is served to other users."
+                "cweId": "CWE-693",
+                "name": "Protection Mechanism Failure",
+                "description": "The product does not use or incorrectly uses a protection mechanism that provides sufficient defense against directed attacks against the product."
+              }
+            ]
+          },
+          "withdrawnAt": null
+        },
+        {
+          "databaseId": 269189,
+          "description": "virtualenv before 20.26.6 allows command injection through the activation scripts for a virtual environment. Magic template strings are not quoted correctly when replacing. NOTE: this is not the same as CVE-2024-9287.",
+          "ghsaId": "GHSA-rqc4-2hc7-8c8v",
+          "id": "GSA_kwCzR0hTQS1ycWM0LTJoYzctOGM4ds4ABBuF",
+          "identifiers": [
+            {
+              "type": "GHSA",
+              "value": "GHSA-rqc4-2hc7-8c8v"
+            },
+            {
+              "type": "CVE",
+              "value": "CVE-2024-53899"
+            }
+          ],
+          "notificationsPermalink": "https://github.com/advisories/GHSA-rqc4-2hc7-8c8v/dependabot",
+          "origin": "UNSPECIFIED",
+          "permalink": "https://github.com/advisories/GHSA-rqc4-2hc7-8c8v",
+          "publishedAt": "2024-11-24T18:31:39Z",
+          "references": [
+            {
+              "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-53899"
+            },
+            {
+              "url": "https://github.com/pypa/virtualenv/issues/2768"
+            },
+            {
+              "url": "https://github.com/pypa/virtualenv/pull/2771"
+            },
+            {
+              "url": "https://github.com/pypa/virtualenv/releases/tag/20.26.6"
+            },
+            {
+              "url": "https://github.com/advisories/GHSA-rqc4-2hc7-8c8v"
+            }
+          ],
+          "severity": "HIGH",
+          "summary": "virtualenv allows command injection through activation scripts for a virtual environment",
+          "updatedAt": "2025-01-13T17:01:52Z",
+          "vulnerabilities": {
+            "edges": [
+              {
+                "severity": "HIGH",
+                "updatedAt": "2025-01-13T17:01:52Z",
+                "firstPatchedVersion": {
+                  "identifier": "20.26.6"
+                },
+                "vulnerableVersionRange": "< 20.26.6",
+                "package": {
+                  "ecosystem": "PIP",
+                  "name": "virtualenv"
                 }
               }
-            ],
-            "totalCount": 1,
-            "pageInfo": {
-              "hasNextPage": false,
-              "hasPreviousPage": false
+            ]
+          },
+          "classification": "GENERAL",
+          "cvssSeverities": {
+            "cvssV3": {
+              "score": 8.4,
+              "vectorString": "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+            },
+            "cvssV4": {
+              "score": 0.0
             }
           },
-          "withdrawnAt": null,
-          "classification": "GENERAL"
+          "cwes": {
+            "edges": [
+              {
+                "cweId": "CWE-77",
+                "name": "Improper Neutralization of Special Elements used in a Command ('Command Injection')",
+                "description": "The product constructs all or part of a command using externally-influenced input from an upstream component, but it does not neutralize or incorrectly neutralizes special elements that could modify the intended command when it is sent to a downstream component."
+              },
+              {
+                "cweId": "CWE-78",
+                "name": "Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')",
+                "description": "The product constructs all or part of an OS command using externally-influenced input from an upstream component, but it does not neutralize or incorrectly neutralizes special elements that could modify the intended OS command when it is sent to a downstream component."
+              }
+            ]
+          },
+          "withdrawnAt": null
+        },
+        {
+          "databaseId": 275375,
+          "description": "A security vulnerability has been identified that allows admin users to access sensitive server environment variables and system properties through user-configurable URLs. Specifically, when configuring backchannel logout URLs or admin URLs, admin users can include placeholders like ${env.VARNAME} or ${PROPNAME}. The server replaces these placeholders with the actual values of environment variables or system properties during URL processing.\n\n",
+          "ghsaId": "GHSA-f4v7-3mww-9gc2",
+          "id": "GSA_kwCzR0hTQS1mNHY3LTNtd3ctOWdjMs4ABDOv",
+          "identifiers": [
+            {
+              "type": "GHSA",
+              "value": "GHSA-f4v7-3mww-9gc2"
+            },
+            {
+              "type": "CVE",
+              "value": "CVE-2024-11736"
+            }
+          ],
+          "notificationsPermalink": "https://github.com/advisories/GHSA-f4v7-3mww-9gc2/dependabot",
+          "origin": "UNSPECIFIED",
+          "permalink": "https://github.com/advisories/GHSA-f4v7-3mww-9gc2",
+          "publishedAt": "2025-01-13T16:58:08Z",
+          "references": [
+            {
+              "url": "https://github.com/keycloak/keycloak/security/advisories/GHSA-f4v7-3mww-9gc2"
+            },
+            {
+              "url": "https://github.com/keycloak/keycloak/commit/7a76858fe4aa39a39fb6b86dd3d2c113d9c59854"
+            },
+            {
+              "url": "https://github.com/advisories/GHSA-f4v7-3mww-9gc2"
+            }
+          ],
+          "severity": "MODERATE",
+          "summary": "Keycloak allows unrestricted admin use of system and environment variables",
+          "updatedAt": "2025-01-13T17:11:27Z",
+          "vulnerabilities": {
+            "edges": [
+              {
+                "severity": "MODERATE",
+                "updatedAt": "2025-01-13T16:58:10Z",
+                "firstPatchedVersion": {
+                  "identifier": "26.0.8"
+                },
+                "vulnerableVersionRange": "< 26.0.8",
+                "package": {
+                  "ecosystem": "MAVEN",
+                  "name": "org.keycloak:keycloak-quarkus-server"
+                }
+              }
+            ]
+          },
+          "classification": "GENERAL",
+          "cvssSeverities": {
+            "cvssV3": {
+              "score": 4.9,
+              "vectorString": "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:N/A:N"
+            },
+            "cvssV4": {
+              "score": 0.0
+            }
+          },
+          "cwes": {
+            "edges": [
+              {
+                "cweId": "CWE-526",
+                "name": "Cleartext Storage of Sensitive Information in an Environment Variable",
+                "description": "The product uses an environment variable to store unencrypted sensitive information."
+              }
+            ]
+          },
+          "withdrawnAt": null
+        },
+        {
+          "databaseId": 275388,
+          "description": "### Overview\nOpenFGA v1.3.8 to v1.8.2 (Helm chart openfga-0.1.38 to openfga-0.2.19, docker v1.3.8 to v.1.8.2) are vulnerable to authorization bypass when certain Check and ListObject calls are executed.\n\n### Am I Affected?\nYou are affected by this authorization bypass vulnerability if you are using OpenFGA v1.3.8 to v1.8.2, specifically under the following conditions: \n1. Calling Check API or ListObjects with a model that uses [conditions](https://openfga.dev/docs/modeling/conditions), and \n2. OpenFGA is configured with caching enabled (`OPENFGA_CHECK_QUERY_CACHE_ENABLED`), and \n3. Check API call or ListObjects API calls contain [contextual tuples](https://openfga.dev/docs/concepts#what-are-contextual-tuples) that include conditions.\n\n### Fix\nUpgrade to v1.8.3. This upgrade is backwards compatible.",
+          "ghsaId": "GHSA-32q6-rr98-cjqv",
+          "id": "GSA_kwCzR0hTQS0zMnE2LXJyOTgtY2pxds4ABDO8",
+          "identifiers": [
+            {
+              "type": "GHSA",
+              "value": "GHSA-32q6-rr98-cjqv"
+            },
+            {
+              "type": "CVE",
+              "value": "CVE-2024-56323"
+            }
+          ],
+          "notificationsPermalink": "https://github.com/advisories/GHSA-32q6-rr98-cjqv/dependabot",
+          "origin": "UNSPECIFIED",
+          "permalink": "https://github.com/advisories/GHSA-32q6-rr98-cjqv",
+          "publishedAt": "2025-01-13T19:59:24Z",
+          "references": [
+            {
+              "url": "https://github.com/openfga/openfga/security/advisories/GHSA-32q6-rr98-cjqv"
+            },
+            {
+              "url": "https://github.com/advisories/GHSA-32q6-rr98-cjqv"
+            }
+          ],
+          "severity": "MODERATE",
+          "summary": "OpenFGA Authorization Bypass",
+          "updatedAt": "2025-01-13T19:59:25Z",
+          "vulnerabilities": {
+            "edges": [
+              {
+                "severity": "MODERATE",
+                "updatedAt": "2025-01-13T19:59:25Z",
+                "firstPatchedVersion": {
+                  "identifier": "1.8.3"
+                },
+                "vulnerableVersionRange": ">= 1.3.8, < 1.8.3",
+                "package": {
+                  "ecosystem": "GO",
+                  "name": "github.com/openfga/openfga"
+                }
+              }
+            ]
+          },
+          "classification": "GENERAL",
+          "cvssSeverities": {
+            "cvssV3": {
+              "score": 0.0
+            },
+            "cvssV4": {
+              "score": 5.8,
+              "vectorString": "CVSS:4.0/AV:N/AC:L/AT:P/PR:L/UI:N/VC:N/VI:N/VA:N/SC:H/SI:H/SA:H"
+            }
+          },
+          "cwes": {
+            "edges": [
+              {
+                "cweId": "CWE-285",
+                "name": "Improper Authorization",
+                "description": "The product does not perform or incorrectly performs an authorization check when an actor attempts to access a resource or perform an action."
+              }
+            ]
+          },
+          "withdrawnAt": null
+        },
+        {
+          "databaseId": 275374,
+          "description": "### Summary\nJte HTML templates with `script` tags or script attributes that include a Javascript template string (backticks) are subject to XSS.\n\n### Details\nThe `javaScriptBlock` and `javaScriptAttribute` methods in the `Escape` class ([source](https://github.com/casid/jte/blob/main/jte-runtime/src/main/java/gg/jte/html/escape/Escape.java#L43-L83)) do not escape backticks, which are used for Javascript [template strings](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#description). Dollar signs in template strings should also be escaped as well to prevent undesired interpolation.\n\n### PoC\n1. Use the [Jte Gradle Plugin](https://jte.gg/gradle-plugin/) with the following code in `src/jte/xss.jte`:\n    ```html\n    @param String someMessage\n    <!DOCTYPE html>\n    <html lang=\"en\">\n    <head>\n        <title>XSS Test</title>\n        <script>window.someVariable = `${someMessage}`;</script>\n    </head>\n    <body>\n    <h1>XSS Test</h1>\n    </body>\n    </html>\n    ```\n2. Use the following Java code to demonstrate the XSS vulnerability:\n    ```java\n    final StringOutput output = new StringOutput();\n    JtexssGenerated.render(new OwaspHtmlTemplateOutput(output), null, \"` + alert(`xss`) + `\");\n    renderHtml(output);\n    ```\n\n### Impact\nHTML templates rendered by Jte's `OwaspHtmlTemplateOutput` in versions less than or equal to `3.1.15` with `script` tags or script attributes that contain Javascript template strings (backticks) are vulnerable.",
+          "ghsaId": "GHSA-vh22-6c6h-rm8q",
+          "id": "GSA_kwCzR0hTQS12aDIyLTZjNmgtcm04cc4ABDOu",
+          "identifiers": [
+            {
+              "type": "GHSA",
+              "value": "GHSA-vh22-6c6h-rm8q"
+            },
+            {
+              "type": "CVE",
+              "value": "CVE-2025-23026"
+            }
+          ],
+          "notificationsPermalink": "https://github.com/advisories/GHSA-vh22-6c6h-rm8q/dependabot",
+          "origin": "UNSPECIFIED",
+          "permalink": "https://github.com/advisories/GHSA-vh22-6c6h-rm8q",
+          "publishedAt": "2025-01-13T16:57:59Z",
+          "references": [
+            {
+              "url": "https://github.com/casid/jte/security/advisories/GHSA-vh22-6c6h-rm8q"
+            },
+            {
+              "url": "https://github.com/casid/jte/commit/a6fb00d53c7b8dbb86de933215dbe1b9191a57f1"
+            },
+            {
+              "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-23026"
+            },
+            {
+              "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#description"
+            },
+            {
+              "url": "https://github.com/casid/jte/blob/main/jte-runtime/src/main/java/gg/jte/html/escape/Escape.java#L43-L83"
+            },
+            {
+              "url": "https://github.com/advisories/GHSA-vh22-6c6h-rm8q"
+            }
+          ],
+          "severity": "MODERATE",
+          "summary": "jte's HTML templates containing Javascript template strings are subject to XSS",
+          "updatedAt": "2025-01-13T21:49:26Z",
+          "vulnerabilities": {
+            "edges": [
+              {
+                "severity": "MODERATE",
+                "updatedAt": "2025-01-13T16:58:00Z",
+                "firstPatchedVersion": {
+                  "identifier": "3.1.16"
+                },
+                "vulnerableVersionRange": "<= 3.1.15",
+                "package": {
+                  "ecosystem": "MAVEN",
+                  "name": "gg.jte:jte"
+                }
+              },
+              {
+                "severity": "MODERATE",
+                "updatedAt": "2025-01-13T16:58:00Z",
+                "firstPatchedVersion": {
+                  "identifier": "3.1.16"
+                },
+                "vulnerableVersionRange": "<= 3.1.15",
+                "package": {
+                  "ecosystem": "MAVEN",
+                  "name": "gg.jte:jte-runtime"
+                }
+              }
+            ]
+          },
+          "classification": "GENERAL",
+          "cvssSeverities": {
+            "cvssV3": {
+              "score": 6.1,
+              "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N"
+            },
+            "cvssV4": {
+              "score": 0.0
+            }
+          },
+          "cwes": {
+            "edges": [
+              {
+                "cweId": "CWE-79",
+                "name": "Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')",
+                "description": "The product does not neutralize or incorrectly neutralizes user-controllable input before it is placed in output that is used as a web page that is served to other users."
+              },
+              {
+                "cweId": "CWE-150",
+                "name": "Improper Neutralization of Escape, Meta, or Control Sequences",
+                "description": "The product receives input from an upstream component, but it does not neutralize or incorrectly neutralizes special elements that could be interpreted as escape, meta, or control character sequences when they are sent to a downstream component."
+              }
+            ]
+          },
+          "withdrawnAt": null
         }
       ],
       "totalCount": 11289,


### PR DESCRIPTION
- jeremylong/open-vulnerability-cli/pull/250

https://docs.github.com/en/graphql/reference/objects#securityadvisory

> cvss is deprecated.
> cvss will be removed. New cvss_severities field will now contain both cvss_v3 and cvss_v4 properties. Removal on 2025-10-01 UTC.

The "CVSS" field will be removed as of 2025-10-01 UTC, so items that were marked as Deprecated will be deleted.