### PR TITLE
fix: epss support added for github security advisories

### DIFF
--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/Epss.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/Epss.java
@@ -1,0 +1,21 @@
+package io.github.jeremylong.openvulnerability.client.ghsa;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Github Security Advisiory EPPS Score
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Epss {
+    Float percentage;
+
+    Float percentile;
+
+    public Float getPercentile() {
+        return percentile;
+    }
+
+    public Float getPercentage() {
+        return percentage;
+    }
+}

--- a/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/SecurityAdvisory.java
+++ b/open-vulnerability-clients/src/main/java/io/github/jeremylong/openvulnerability/client/ghsa/SecurityAdvisory.java
@@ -28,7 +28,7 @@ import java.util.List;
 import java.util.Objects;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-@JsonPropertyOrder({"databaseId", "description", "ghsaId", "id", "identifiers", "notificationsPermalink", "origin",
+@JsonPropertyOrder({"databaseId", "description", "ghsaId", "id", "identifiers","epss", "notificationsPermalink", "origin",
         "permalink", "publishedAt", "references", "severity", "summary", "updatedAt", "vulnerabilities",
         "classification", "cvssSeverities", "cwes", "withdrawnAt"})
 public class SecurityAdvisory implements Serializable {
@@ -52,6 +52,9 @@ public class SecurityAdvisory implements Serializable {
 
     @JsonProperty("identifiers")
     private List<Identifier> identifiers;
+
+    @JsonProperty("epss")
+    private Epss epss;
 
     @JsonProperty("notificationsPermalink")
     private String notificationsPermalink;
@@ -253,6 +256,15 @@ public class SecurityAdvisory implements Serializable {
     public CWEs getCwes() {
         return cwes;
     }
+
+    /**
+     * Returns EPSS score for security advisories
+     * @return EPSS score for security advisories
+     */
+    public Epss getEpss() {
+        return epss;
+    }
+
 
     /**
      * The vulnerable packages associated with the advisory.

--- a/open-vulnerability-clients/src/main/resources/securityAdvisories.mustache
+++ b/open-vulnerability-clients/src/main/resources/securityAdvisories.mustache
@@ -21,6 +21,7 @@ query {
         type
         value
       }
+      epss { percentage, percentile }
       notificationsPermalink
       origin
       permalink


### PR DESCRIPTION
Earlier score was not appearing for advisiories.

This PR introduces support for the Exploit Prediction Scoring System (EPSS) for github security advisories.

- Adding EPSS fields (percentage and percentile) to the GraphQL query templates
- Updating the SecurityAdvisory POJO to include new EPSS attributes for deserialization.

