### PR TITLE
fix: Correct parsing of Provider Urgency from CVSSv4 vector strings

### DIFF
--- a/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/CvssV4Data.java
+++ b/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/CvssV4Data.java
@@ -2032,17 +2032,12 @@ public class CvssV4Data implements Serializable {
         @JsonCreator
         public static ProviderUrgencyType fromValue(String value) {
             // allow conversion from vector string
-            if (value.length() == 1) {
-                if ("x".equalsIgnoreCase(value)) {
-                    return NOT_DEFINED;
-                }
-                for (ProviderUrgencyType t : values()) {
-                    if (t.value.startsWith(value.toUpperCase())) {
-                        return t;
-                    }
-                }
+            if ("x".equalsIgnoreCase(value)) {
+                return NOT_DEFINED;
             }
-            ProviderUrgencyType constant = CONSTANTS.get(value);
+            // Vector string serializations are [X,Clear,Green,Amber,Red] unlike other types
+            // We do a lenient match here for simplicity
+            ProviderUrgencyType constant = CONSTANTS.get(value.toUpperCase());
             if (constant == null) {
                 throw new IllegalArgumentException(value);
             } else {

--- a/src/test/java/io/github/jeremylong/openvulnerability/client/nvd/CvssEnumTestSupport.java
+++ b/src/test/java/io/github/jeremylong/openvulnerability/client/nvd/CvssEnumTestSupport.java
@@ -1,0 +1,50 @@
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2026 Jeremy Long. All Rights Reserved.
+ */
+package io.github.jeremylong.openvulnerability.client.nvd;
+
+import org.junit.jupiter.params.provider.Arguments;
+
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+final class CvssEnumTestSupport {
+
+    private CvssEnumTestSupport() {
+    }
+
+    static Arguments allEnumValues(Class<? extends Enum<?>> enumClass, Function<String, ? extends Enum<?>> mapper) {
+        return Arguments.of(enumClass.getSimpleName(), enumClass, mapper);
+    }
+
+    static Arguments vectorCase(Class<? extends Enum<?>> enumClass, Function<String, ? extends Enum<?>> mapper,
+            String rawValue, Enum<?> expected) {
+        return Arguments.of(enumClass.getSimpleName(), mapper, rawValue, expected);
+    }
+
+    static Arguments notDefinedCase(Class<? extends Enum<?>> enumClass, Function<String, ? extends Enum<?>> mapper,
+            Enum<?> expected) {
+        return Arguments.of(enumClass.getSimpleName(), mapper, expected);
+    }
+
+    static void assertCanonicalMappings(Class<? extends Enum<?>> enumClass,
+            Function<String, ? extends Enum<?>> mapper) {
+        for (Enum<?> constant : enumClass.getEnumConstants()) {
+            assertSame(constant, mapper.apply(constant.toString()));
+        }
+    }
+}

--- a/src/test/java/io/github/jeremylong/openvulnerability/client/nvd/CvssV2DataTest.java
+++ b/src/test/java/io/github/jeremylong/openvulnerability/client/nvd/CvssV2DataTest.java
@@ -1,0 +1,107 @@
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2026 Jeremy Long. All Rights Reserved.
+ */
+package io.github.jeremylong.openvulnerability.client.nvd;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import static io.github.jeremylong.openvulnerability.client.nvd.CvssEnumTestSupport.*;
+import static io.github.jeremylong.openvulnerability.client.nvd.CvssV2Data.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+
+class CvssV2DataTest {
+
+    @Nested
+    class TypeMappings {
+        @ParameterizedTest(name = "{0} canonical values")
+        @MethodSource("io.github.jeremylong.openvulnerability.client.nvd.CvssV2DataTest#canonicalMappings")
+        void shouldMapCanonicalValues(String ignoredDescriptiveType, Class<? extends Enum<?>> enumClass,
+                Function<String, ? extends Enum<?>> mapper) {
+            assertCanonicalMappings(enumClass, mapper);
+        }
+
+        @ParameterizedTest(name = "{0} vector from {2}")
+        @MethodSource("io.github.jeremylong.openvulnerability.client.nvd.CvssV2DataTest#vectorStringMappings")
+        void shouldMapVectorStringValues(String ignoredDescriptiveType, Function<String, ? extends Enum<?>> mapper,
+                String rawValue, Enum<?> expected) {
+            assertEquals(expected, mapper.apply(rawValue));
+        }
+
+        @ParameterizedTest(name = "{0} vector not defined")
+        @MethodSource("io.github.jeremylong.openvulnerability.client.nvd.CvssV2DataTest#notDefinedMappings")
+        void shouldMapNotDefinedVectorStrings(String ignoredDescriptiveType, Function<String, ? extends Enum<?>> mapper,
+                Enum<?> expected) {
+            assertEquals(expected, mapper.apply("x"));
+            assertEquals(expected, mapper.apply("X"));
+        }
+
+        @ParameterizedTest(name = "{0} rejects unknown")
+        @MethodSource("io.github.jeremylong.openvulnerability.client.nvd.CvssV2DataTest#canonicalMappings")
+        void shouldRejectUnknownValues(String ignoredDescriptiveType, Class<? extends Enum<?>> ignoredEnumClass,
+                Function<String, ? extends Enum<?>> mapper) {
+            assertThrowsExactly(IllegalArgumentException.class, () -> mapper.apply("invalid"));
+            assertThrowsExactly(IllegalArgumentException.class, () -> mapper.apply("*"));
+        }
+    }
+
+    private static Stream<Arguments> canonicalMappings() {
+        return Stream.of(allEnumValues(AccessComplexityType.class, AccessComplexityType::fromValue),
+                allEnumValues(AccessVectorType.class, AccessVectorType::fromValue),
+                allEnumValues(AuthenticationType.class, AuthenticationType::fromValue),
+                allEnumValues(CiaRequirementType.class, CiaRequirementType::fromValue),
+                allEnumValues(CiaType.class, CiaType::fromValue),
+                allEnumValues(CollateralDamagePotentialType.class, CollateralDamagePotentialType::fromValue),
+                allEnumValues(ExploitabilityType.class, ExploitabilityType::fromValue),
+                allEnumValues(RemediationLevelType.class, RemediationLevelType::fromValue),
+                allEnumValues(ReportConfidenceType.class, ReportConfidenceType::fromValue),
+                allEnumValues(TargetDistributionType.class, TargetDistributionType::fromValue),
+                allEnumValues(Version.class, Version::fromValue));
+    }
+
+    private static Stream<Arguments> vectorStringMappings() {
+        return Stream.of(
+                vectorCase(AccessComplexityType.class, AccessComplexityType::fromValue, "L", AccessComplexityType.LOW),
+                vectorCase(AccessVectorType.class, AccessVectorType::fromValue, "L", AccessVectorType.LOCAL),
+                vectorCase(AuthenticationType.class, AuthenticationType::fromValue, "N", AuthenticationType.NONE),
+                vectorCase(CiaRequirementType.class, CiaRequirementType::fromValue, "M", CiaRequirementType.MEDIUM),
+                vectorCase(CiaType.class, CiaType::fromValue, "C", CiaType.COMPLETE),
+                vectorCase(CollateralDamagePotentialType.class, CollateralDamagePotentialType::fromValue, "H",
+                        CollateralDamagePotentialType.HIGH),
+                vectorCase(ExploitabilityType.class, ExploitabilityType::fromValue, "F", ExploitabilityType.FUNCTIONAL),
+                vectorCase(RemediationLevelType.class, RemediationLevelType::fromValue, "W",
+                        RemediationLevelType.WORKAROUND),
+                vectorCase(ReportConfidenceType.class, ReportConfidenceType::fromValue, "C",
+                        ReportConfidenceType.CONFIRMED),
+                vectorCase(TargetDistributionType.class, TargetDistributionType::fromValue, "M",
+                        TargetDistributionType.MEDIUM));
+    }
+
+    private static Stream<Arguments> notDefinedMappings() {
+        return Stream.of(
+                notDefinedCase(CiaRequirementType.class, CiaRequirementType::fromValue, CiaRequirementType.NOT_DEFINED),
+                notDefinedCase(RemediationLevelType.class, RemediationLevelType::fromValue,
+                        RemediationLevelType.NOT_DEFINED),
+                notDefinedCase(TargetDistributionType.class, TargetDistributionType::fromValue,
+                        TargetDistributionType.NOT_DEFINED));
+    }
+}

--- a/src/test/java/io/github/jeremylong/openvulnerability/client/nvd/CvssV3DataTest.java
+++ b/src/test/java/io/github/jeremylong/openvulnerability/client/nvd/CvssV3DataTest.java
@@ -1,0 +1,135 @@
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2026 Jeremy Long. All Rights Reserved.
+ */
+package io.github.jeremylong.openvulnerability.client.nvd;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import static io.github.jeremylong.openvulnerability.client.nvd.CvssEnumTestSupport.*;
+import static io.github.jeremylong.openvulnerability.client.nvd.CvssV3Data.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+
+class CvssV3DataTest {
+
+    @Nested
+    class TypeMappings {
+        @ParameterizedTest(name = "{0} canonical values")
+        @MethodSource("io.github.jeremylong.openvulnerability.client.nvd.CvssV3DataTest#canonicalMappings")
+        void shouldMapCanonicalValues(String ignoredDescriptiveType, Class<? extends Enum<?>> enumClass,
+                Function<String, ? extends Enum<?>> mapper) {
+            assertCanonicalMappings(enumClass, mapper);
+        }
+
+        @ParameterizedTest(name = "{0} vector from {2}")
+        @MethodSource("io.github.jeremylong.openvulnerability.client.nvd.CvssV3DataTest#vectorStringMappings")
+        void shouldMapVectorStringValues(String ignoredDescriptiveType, Function<String, ? extends Enum<?>> mapper,
+                String rawValue, Enum<?> expected) {
+            assertEquals(expected, mapper.apply(rawValue));
+        }
+
+        @ParameterizedTest(name = "{0} vector not defined")
+        @MethodSource("io.github.jeremylong.openvulnerability.client.nvd.CvssV3DataTest#notDefinedMappings")
+        void shouldMapNotDefinedVectorStrings(String ignoredDescriptiveType, Function<String, ? extends Enum<?>> mapper,
+                Enum<?> expected) {
+            assertEquals(expected, mapper.apply("x"));
+            assertEquals(expected, mapper.apply("X"));
+        }
+
+        @ParameterizedTest(name = "{0} rejects unknown")
+        @MethodSource("io.github.jeremylong.openvulnerability.client.nvd.CvssV3DataTest#canonicalMappings")
+        void shouldRejectUnknownValues(String ignoredDescriptiveType, Class<? extends Enum<?>> ignoredEnumClass,
+                Function<String, ? extends Enum<?>> mapper) {
+            assertThrowsExactly(IllegalArgumentException.class, () -> mapper.apply("invalid"));
+            assertThrowsExactly(IllegalArgumentException.class, () -> mapper.apply("*"));
+        }
+    }
+
+    private static Stream<Arguments> canonicalMappings() {
+        return Stream.of(allEnumValues(AttackComplexityType.class, AttackComplexityType::fromValue),
+                allEnumValues(AttackVectorType.class, AttackVectorType::fromValue),
+                allEnumValues(CiaRequirementType.class, CiaRequirementType::fromValue),
+                allEnumValues(CiaType.class, CiaType::fromValue),
+                allEnumValues(ConfidenceType.class, ConfidenceType::fromValue),
+                allEnumValues(ExploitCodeMaturityType.class, ExploitCodeMaturityType::fromValue),
+                allEnumValues(ModifiedAttackComplexityType.class, ModifiedAttackComplexityType::fromValue),
+                allEnumValues(ModifiedAttackVectorType.class, ModifiedAttackVectorType::fromValue),
+                allEnumValues(ModifiedCiaType.class, ModifiedCiaType::fromValue),
+                allEnumValues(ModifiedPrivilegesRequiredType.class, ModifiedPrivilegesRequiredType::fromValue),
+                allEnumValues(ModifiedScopeType.class, ModifiedScopeType::fromValue),
+                allEnumValues(ModifiedUserInteractionType.class, ModifiedUserInteractionType::fromValue),
+                allEnumValues(PrivilegesRequiredType.class, PrivilegesRequiredType::fromValue),
+                allEnumValues(RemediationLevelType.class, RemediationLevelType::fromValue),
+                allEnumValues(ScopeType.class, ScopeType::fromValue),
+                allEnumValues(SeverityType.class, SeverityType::fromValue),
+                allEnumValues(UserInteractionType.class, UserInteractionType::fromValue),
+                allEnumValues(Version.class, Version::fromValue));
+    }
+
+    private static Stream<Arguments> vectorStringMappings() {
+        return Stream.of(
+                vectorCase(AttackComplexityType.class, AttackComplexityType::fromValue, "L", AttackComplexityType.LOW),
+                vectorCase(AttackVectorType.class, AttackVectorType::fromValue, "P", AttackVectorType.PHYSICAL),
+                vectorCase(CiaRequirementType.class, CiaRequirementType::fromValue, "M", CiaRequirementType.MEDIUM),
+                vectorCase(CiaType.class, CiaType::fromValue, "H", CiaType.HIGH),
+                vectorCase(ConfidenceType.class, ConfidenceType::fromValue, "C", ConfidenceType.CONFIRMED),
+                vectorCase(ExploitCodeMaturityType.class, ExploitCodeMaturityType::fromValue, "H",
+                        ExploitCodeMaturityType.HIGH),
+                vectorCase(ModifiedAttackComplexityType.class, ModifiedAttackComplexityType::fromValue, "L",
+                        ModifiedAttackComplexityType.LOW),
+                vectorCase(ModifiedAttackVectorType.class, ModifiedAttackVectorType::fromValue, "L",
+                        ModifiedAttackVectorType.LOCAL),
+                vectorCase(ModifiedCiaType.class, ModifiedCiaType::fromValue, "H", ModifiedCiaType.HIGH),
+                vectorCase(ModifiedPrivilegesRequiredType.class, ModifiedPrivilegesRequiredType::fromValue, "N",
+                        ModifiedPrivilegesRequiredType.NONE),
+                vectorCase(ModifiedScopeType.class, ModifiedScopeType::fromValue, "C", ModifiedScopeType.CHANGED),
+                vectorCase(ModifiedUserInteractionType.class, ModifiedUserInteractionType::fromValue, "R",
+                        ModifiedUserInteractionType.REQUIRED),
+                vectorCase(PrivilegesRequiredType.class, PrivilegesRequiredType::fromValue, "L",
+                        PrivilegesRequiredType.LOW),
+                vectorCase(RemediationLevelType.class, RemediationLevelType::fromValue, "W",
+                        RemediationLevelType.WORKAROUND),
+                vectorCase(ScopeType.class, ScopeType::fromValue, "C", ScopeType.CHANGED),
+                vectorCase(SeverityType.class, SeverityType::fromValue, "C", SeverityType.CRITICAL), vectorCase(
+                        UserInteractionType.class, UserInteractionType::fromValue, "R", UserInteractionType.REQUIRED));
+    }
+
+    private static Stream<Arguments> notDefinedMappings() {
+        return Stream.of(
+                notDefinedCase(CiaRequirementType.class, CiaRequirementType::fromValue, CiaRequirementType.NOT_DEFINED),
+                notDefinedCase(ConfidenceType.class, ConfidenceType::fromValue, ConfidenceType.NOT_DEFINED),
+                notDefinedCase(ExploitCodeMaturityType.class, ExploitCodeMaturityType::fromValue,
+                        ExploitCodeMaturityType.NOT_DEFINED),
+                notDefinedCase(ModifiedAttackComplexityType.class, ModifiedAttackComplexityType::fromValue,
+                        ModifiedAttackComplexityType.NOT_DEFINED),
+                notDefinedCase(ModifiedAttackVectorType.class, ModifiedAttackVectorType::fromValue,
+                        ModifiedAttackVectorType.NOT_DEFINED),
+                notDefinedCase(ModifiedCiaType.class, ModifiedCiaType::fromValue, ModifiedCiaType.NOT_DEFINED),
+                notDefinedCase(ModifiedPrivilegesRequiredType.class, ModifiedPrivilegesRequiredType::fromValue,
+                        ModifiedPrivilegesRequiredType.NOT_DEFINED),
+                notDefinedCase(ModifiedScopeType.class, ModifiedScopeType::fromValue, ModifiedScopeType.NOT_DEFINED),
+                notDefinedCase(ModifiedUserInteractionType.class, ModifiedUserInteractionType::fromValue,
+                        ModifiedUserInteractionType.NOT_DEFINED),
+                notDefinedCase(RemediationLevelType.class, RemediationLevelType::fromValue,
+                        RemediationLevelType.NOT_DEFINED));
+    }
+}

--- a/src/test/java/io/github/jeremylong/openvulnerability/client/nvd/CvssV4DataTest.java
+++ b/src/test/java/io/github/jeremylong/openvulnerability/client/nvd/CvssV4DataTest.java
@@ -17,8 +17,15 @@
 package io.github.jeremylong.openvulnerability.client.nvd;
 
 import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
+import java.util.Locale;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import static io.github.jeremylong.openvulnerability.client.nvd.CvssEnumTestSupport.*;
 import static io.github.jeremylong.openvulnerability.client.nvd.CvssV4Data.*;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -26,16 +33,149 @@ class CvssV4DataTest {
 
     @Nested
     class TypeMappings {
-        @Test
-        void shouldMapProviderUrgency() {
-            assertEquals(ProviderUrgencyType.NOT_DEFINED, ProviderUrgencyType.fromValue("x"));
-            assertEquals(ProviderUrgencyType.NOT_DEFINED, ProviderUrgencyType.fromValue("X"));
-            assertEquals(ProviderUrgencyType.NOT_DEFINED, ProviderUrgencyType.fromValue("NOT_DEFINED"));
-
-            assertEquals(ProviderUrgencyType.AMBER, ProviderUrgencyType.fromValue("AMBER"));
-            assertEquals(ProviderUrgencyType.AMBER, ProviderUrgencyType.fromValue("Amber"));
-
-            assertThrowsExactly(IllegalArgumentException.class, () -> ProviderUrgencyType.fromValue("A"));
+        @ParameterizedTest(name = "{0} canonical values")
+        @MethodSource("io.github.jeremylong.openvulnerability.client.nvd.CvssV4DataTest#canonicalMappings")
+        void shouldMapCanonicalValues(String ignoredDescriptiveType, Class<? extends Enum<?>> enumClass,
+                Function<String, ? extends Enum<?>> mapper) {
+            assertCanonicalMappings(enumClass, mapper);
         }
+
+        @ParameterizedTest(name = "{0} vector from {2}")
+        @MethodSource("io.github.jeremylong.openvulnerability.client.nvd.CvssV4DataTest#vectorStringMappings")
+        void shouldMapVectorStringValues(String ignoredDescriptiveType, Function<String, ? extends Enum<?>> mapper,
+                String rawValue, Enum<?> expected) {
+            assertEquals(expected, mapper.apply(rawValue));
+        }
+
+        @ParameterizedTest(name = "{0} vector case insensitive from {2}")
+        @MethodSource("io.github.jeremylong.openvulnerability.client.nvd.CvssV4DataTest#vectorStringCaseInsensitiveMappings")
+        void shouldMapVectorStringValuesCaseInsensitive(String ignoredDescriptiveType,
+                Function<String, ? extends Enum<?>> mapper, String rawValue, Enum<?> expected) {
+            assertEquals(expected, mapper.apply(rawValue));
+        }
+
+        @ParameterizedTest(name = "{0} vector not defined")
+        @MethodSource("io.github.jeremylong.openvulnerability.client.nvd.CvssV4DataTest#notDefinedMappings")
+        void shouldMapNotDefinedVectorStrings(String ignoredDescriptiveType, Function<String, ? extends Enum<?>> mapper,
+                Enum<?> expected) {
+            assertEquals(expected, mapper.apply("x"));
+            assertEquals(expected, mapper.apply("X"));
+        }
+
+        @ParameterizedTest(name = "{0} rejects unknown")
+        @MethodSource("io.github.jeremylong.openvulnerability.client.nvd.CvssV4DataTest#canonicalMappings")
+        void shouldRejectUnknownValues(String ignoredDescriptiveType, Class<? extends Enum<?>> ignoredEnumClass,
+                Function<String, ? extends Enum<?>> mapper) {
+            assertThrowsExactly(IllegalArgumentException.class, () -> mapper.apply("invalid"));
+            assertThrowsExactly(IllegalArgumentException.class, () -> mapper.apply("*"));
+        }
+    }
+
+    private static Stream<Arguments> canonicalMappings() {
+        return Stream.of(allEnumValues(AttackComplexityType.class, AttackComplexityType::fromValue),
+                allEnumValues(AttackVectorType.class, AttackVectorType::fromValue),
+                allEnumValues(CiaRequirementType.class, CiaRequirementType::fromValue),
+                allEnumValues(CiaType.class, CiaType::fromValue),
+                allEnumValues(ExploitMaturityType.class, ExploitMaturityType::fromValue),
+                allEnumValues(ModifiedAttackComplexityType.class, ModifiedAttackComplexityType::fromValue),
+                allEnumValues(AttackRequirementsType.class, AttackRequirementsType::fromValue),
+                allEnumValues(ModifiedAttackRequirementsType.class, ModifiedAttackRequirementsType::fromValue),
+                allEnumValues(ModifiedAttackVectorType.class, ModifiedAttackVectorType::fromValue),
+                allEnumValues(ModifiedCiaType.class, ModifiedCiaType::fromValue),
+                allEnumValues(ModifiedSubCType.class, ModifiedSubCType::fromValue),
+                allEnumValues(ModifiedSubIaType.class, ModifiedSubIaType::fromValue),
+                allEnumValues(SafetyType.class, SafetyType::fromValue),
+                allEnumValues(AutomatableType.class, AutomatableType::fromValue),
+                allEnumValues(RecoveryType.class, RecoveryType::fromValue),
+                allEnumValues(ValueDensityType.class, ValueDensityType::fromValue),
+                allEnumValues(VulnerabilityResponseEffortType.class, VulnerabilityResponseEffortType::fromValue),
+                allEnumValues(ProviderUrgencyType.class, ProviderUrgencyType::fromValue),
+                allEnumValues(ModifiedPrivilegesRequiredType.class, ModifiedPrivilegesRequiredType::fromValue),
+                allEnumValues(ModifiedVulnCiaType.class, ModifiedVulnCiaType::fromValue),
+                allEnumValues(ModifiedUserInteractionType.class, ModifiedUserInteractionType::fromValue),
+                allEnumValues(PrivilegesRequiredType.class, PrivilegesRequiredType::fromValue),
+                allEnumValues(RemediationLevelType.class, RemediationLevelType::fromValue),
+                allEnumValues(SeverityType.class, SeverityType::fromValue),
+                allEnumValues(UserInteractionType.class, UserInteractionType::fromValue),
+                allEnumValues(Version.class, Version::fromValue));
+    }
+
+    private static Stream<Arguments> vectorStringMappings() {
+        return Stream.of(
+                vectorCase(AttackComplexityType.class, AttackComplexityType::fromValue, "L", AttackComplexityType.LOW),
+                vectorCase(AttackVectorType.class, AttackVectorType::fromValue, "P", AttackVectorType.PHYSICAL),
+                vectorCase(CiaRequirementType.class, CiaRequirementType::fromValue, "M", CiaRequirementType.MEDIUM),
+                vectorCase(CiaType.class, CiaType::fromValue, "H", CiaType.HIGH),
+                vectorCase(ExploitMaturityType.class, ExploitMaturityType::fromValue, "P",
+                        ExploitMaturityType.PROOF_OF_CONCEPT),
+                vectorCase(ModifiedAttackComplexityType.class, ModifiedAttackComplexityType::fromValue, "H",
+                        ModifiedAttackComplexityType.HIGH),
+                vectorCase(AttackRequirementsType.class, AttackRequirementsType::fromValue, "P",
+                        AttackRequirementsType.PRESENT),
+                vectorCase(ModifiedAttackRequirementsType.class, ModifiedAttackRequirementsType::fromValue, "N",
+                        ModifiedAttackRequirementsType.NONE),
+                vectorCase(ModifiedAttackVectorType.class, ModifiedAttackVectorType::fromValue, "A",
+                        ModifiedAttackVectorType.ADJACENT),
+                vectorCase(ModifiedCiaType.class, ModifiedCiaType::fromValue, "L", ModifiedCiaType.LOW),
+                vectorCase(ModifiedSubCType.class, ModifiedSubCType::fromValue, "N", ModifiedSubCType.NEGLIGIBLE),
+                vectorCase(ModifiedSubIaType.class, ModifiedSubIaType::fromValue, "S", ModifiedSubIaType.SAFETY),
+                vectorCase(SafetyType.class, SafetyType::fromValue, "P", SafetyType.PRESENT),
+                vectorCase(AutomatableType.class, AutomatableType::fromValue, "Y", AutomatableType.YES),
+                vectorCase(RecoveryType.class, RecoveryType::fromValue, "U", RecoveryType.USER),
+                vectorCase(ValueDensityType.class, ValueDensityType::fromValue, "C", ValueDensityType.CONCENTRATED),
+                vectorCase(VulnerabilityResponseEffortType.class, VulnerabilityResponseEffortType::fromValue, "M",
+                        VulnerabilityResponseEffortType.MODERATE),
+                vectorCase(ModifiedPrivilegesRequiredType.class, ModifiedPrivilegesRequiredType::fromValue, "N",
+                        ModifiedPrivilegesRequiredType.NONE),
+                vectorCase(ModifiedVulnCiaType.class, ModifiedVulnCiaType::fromValue, "H", ModifiedVulnCiaType.HIGH),
+                vectorCase(ModifiedUserInteractionType.class, ModifiedUserInteractionType::fromValue, "A",
+                        ModifiedUserInteractionType.ACTIVE),
+                vectorCase(PrivilegesRequiredType.class, PrivilegesRequiredType::fromValue, "L",
+                        PrivilegesRequiredType.LOW),
+                vectorCase(ProviderUrgencyType.class, ProviderUrgencyType::fromValue, "Amber",
+                        ProviderUrgencyType.AMBER),
+                vectorCase(RemediationLevelType.class, RemediationLevelType::fromValue, "W",
+                        RemediationLevelType.WORKAROUND),
+                vectorCase(SeverityType.class, SeverityType::fromValue, "C", SeverityType.CRITICAL),
+                vectorCase(UserInteractionType.class, UserInteractionType::fromValue, "A", UserInteractionType.ACTIVE));
+    }
+
+    private static Stream<Arguments> vectorStringCaseInsensitiveMappings() {
+        return vectorStringMappings().map(arguments -> {
+            Object[] values = arguments.get();
+            return Arguments.of(values[0], values[1], values[2].toString().toLowerCase(Locale.ROOT), values[3]);
+        });
+    }
+
+    private static Stream<Arguments> notDefinedMappings() {
+        return Stream.of(
+                notDefinedCase(CiaRequirementType.class, CiaRequirementType::fromValue, CiaRequirementType.NOT_DEFINED),
+                notDefinedCase(ExploitMaturityType.class, ExploitMaturityType::fromValue,
+                        ExploitMaturityType.NOT_DEFINED),
+                notDefinedCase(ModifiedAttackComplexityType.class, ModifiedAttackComplexityType::fromValue,
+                        ModifiedAttackComplexityType.NOT_DEFINED),
+                notDefinedCase(ModifiedAttackRequirementsType.class, ModifiedAttackRequirementsType::fromValue,
+                        ModifiedAttackRequirementsType.NOT_DEFINED),
+                notDefinedCase(ModifiedAttackVectorType.class, ModifiedAttackVectorType::fromValue,
+                        ModifiedAttackVectorType.NOT_DEFINED),
+                notDefinedCase(ModifiedCiaType.class, ModifiedCiaType::fromValue, ModifiedCiaType.NOT_DEFINED),
+                notDefinedCase(ModifiedSubCType.class, ModifiedSubCType::fromValue, ModifiedSubCType.NOT_DEFINED),
+                notDefinedCase(ModifiedSubIaType.class, ModifiedSubIaType::fromValue, ModifiedSubIaType.NOT_DEFINED),
+                notDefinedCase(SafetyType.class, SafetyType::fromValue, SafetyType.NOT_DEFINED),
+                notDefinedCase(AutomatableType.class, AutomatableType::fromValue, AutomatableType.NOT_DEFINED),
+                notDefinedCase(RecoveryType.class, RecoveryType::fromValue, RecoveryType.NOT_DEFINED),
+                notDefinedCase(ValueDensityType.class, ValueDensityType::fromValue, ValueDensityType.NOT_DEFINED),
+                notDefinedCase(VulnerabilityResponseEffortType.class, VulnerabilityResponseEffortType::fromValue,
+                        VulnerabilityResponseEffortType.NOT_DEFINED),
+                notDefinedCase(ProviderUrgencyType.class, ProviderUrgencyType::fromValue,
+                        ProviderUrgencyType.NOT_DEFINED),
+                notDefinedCase(ModifiedPrivilegesRequiredType.class, ModifiedPrivilegesRequiredType::fromValue,
+                        ModifiedPrivilegesRequiredType.NOT_DEFINED),
+                notDefinedCase(ModifiedVulnCiaType.class, ModifiedVulnCiaType::fromValue,
+                        ModifiedVulnCiaType.NOT_DEFINED),
+                notDefinedCase(ModifiedUserInteractionType.class, ModifiedUserInteractionType::fromValue,
+                        ModifiedUserInteractionType.NOT_DEFINED),
+                notDefinedCase(RemediationLevelType.class, RemediationLevelType::fromValue,
+                        RemediationLevelType.NOT_DEFINED));
     }
 }

--- a/src/test/java/io/github/jeremylong/openvulnerability/client/nvd/CvssV4DataTest.java
+++ b/src/test/java/io/github/jeremylong/openvulnerability/client/nvd/CvssV4DataTest.java
@@ -1,0 +1,41 @@
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) 2026 Jeremy Long. All Rights Reserved.
+ */
+package io.github.jeremylong.openvulnerability.client.nvd;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static io.github.jeremylong.openvulnerability.client.nvd.CvssV4Data.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+class CvssV4DataTest {
+
+    @Nested
+    class TypeMappings {
+        @Test
+        void shouldMapProviderUrgency() {
+            assertEquals(ProviderUrgencyType.NOT_DEFINED, ProviderUrgencyType.fromValue("x"));
+            assertEquals(ProviderUrgencyType.NOT_DEFINED, ProviderUrgencyType.fromValue("X"));
+            assertEquals(ProviderUrgencyType.NOT_DEFINED, ProviderUrgencyType.fromValue("NOT_DEFINED"));
+
+            assertEquals(ProviderUrgencyType.AMBER, ProviderUrgencyType.fromValue("AMBER"));
+            assertEquals(ProviderUrgencyType.AMBER, ProviderUrgencyType.fromValue("Amber"));
+
+            assertThrowsExactly(IllegalArgumentException.class, () -> ProviderUrgencyType.fromValue("A"));
+        }
+    }
+}


### PR DESCRIPTION
- fixes #100 
  - related downstream ODC issue: https://github.com/dependency-check/DependencyCheck/issues/8376
  
As noted more fully at https://github.com/jeremylong/open-vulnerability-clients/issues/100#issuecomment-4090985712 the spec does not denote Provider Urgency shorthand representations for vector strings for anything except `X` -> `NOT_DEFINED`; and instead has title case values `[X,Clear,Green,Amber,Red]`.

Since we do case-insensitive matches to the single char variants right now (which is not strictly in spec) and these methods seem intended to be helpful rather than strict, it seems OK and simplest to do a case-insensitive compare rather than normalizing to title case for comparison.