### PR TITLE
build: test across Java versions while continuing to target Java 11

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,4 +7,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "monthly"
+    groups:
+      actions-deps:
+        patterns: [ "*" ]

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -23,7 +23,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        ./gradlew build --info
+        ./gradlew build --console=colored
     - name: Archive test reports
       id: archive-logs
       if: always()
@@ -32,4 +32,4 @@ jobs:
         name: test-reports
         retention-days: 7
         path: |
-          open-vulnerability-clients/build/reports/tests
+            build/reports/tests/test

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -11,25 +11,37 @@ permissions:
 
 jobs:
   build:
+    strategy:
+      matrix:
+        jdk_default_version: [ '25' ]                # Single JDK version to run Gradle with and use for compilation etc
+        jdk_test_version: [ '11', '17', '21', '25' ] # JDK version to run tests using
+      fail-fast: false
+
+    name: Build and Test (JDK ${{ matrix.jdk_test_version }}${{ matrix.jdk_test_version == matrix.jdk_default_version && ' - Default' || '' }})
+
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
-    - name: Set up JDK 17
-      uses: actions/setup-java@v5
+    - name: Set up JDKs
+      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
       with:
-        java-version: '17'
+        java-version: | # last version takes precedence as default
+          ${{ matrix.jdk_test_version }}
+          ${{ matrix.jdk_default_version }}
         distribution: 'temurin'
+        check-latest: true
+        cache: 'gradle'
     - name: Run build
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        ./gradlew build --console=colored
+        ./gradlew build --console=colored -PtestToolchainVersion=${{ matrix.jdk_test_version }}
     - name: Archive test reports
       id: archive-logs
       if: always()
       uses: actions/upload-artifact@v7
       with:
-        name: test-reports
+        name: test-reports-${{ matrix.jdk_test_version }}
         retention-days: 7
         path: |
-            build/reports/tests/test
+          build/reports/tests/test

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -21,7 +21,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Set up JDKs
       uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
       with:
@@ -39,7 +39,7 @@ jobs:
     - name: Archive test reports
       id: archive-logs
       if: always()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       with:
         name: test-reports-${{ matrix.jdk_test_version }}
         retention-days: 7

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,19 +34,18 @@ dependencies {
 java {
     withSourcesJar()
     withJavadocJar()
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
 }
 
-tasks.register<Copy>("addVesionResource") {
+tasks.register<Copy>("addVersionResource") {
     from(".")
     include("gradle.properties")
     into("build/resources/main")
     rename("gradle.properties", "version.properties")
 }
 
-tasks.named("compileJava") {
-    dependsOn("addVesionResource")
+tasks.named<JavaCompile>("compileJava") {
+    dependsOn("addVersionResource")
+    options.release.set(11)
 }
 
 tasks.named<Test>("test") {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,14 @@ plugins {
 description = "Clients for vulnerability sources"
 group = "io.github.jeremylong"
 
+val targetJavaVersion = 11
+val gradleJavaVersion = JavaLanguageVersion.current()
+val testToolchainVersion = providers.gradleProperty("testToolchainVersion")
+    .map(JavaLanguageVersion::of)
+    .orElse(gradleJavaVersion)
+
+logger.lifecycle("Build targets $targetJavaVersion using JDK $gradleJavaVersion (test with JDK ${testToolchainVersion.get()})")
+
 repositories {
     mavenCentral()
 }
@@ -36,20 +44,28 @@ java {
     withJavadocJar()
 }
 
-tasks.register<Copy>("addVersionResource") {
+tasks.register<Copy>("addVersionResource").configure {
     from(".")
     include("gradle.properties")
     into("build/resources/main")
     rename("gradle.properties", "version.properties")
 }
 
-tasks.named<JavaCompile>("compileJava") {
+tasks.named<JavaCompile>("compileJava").configure {
     dependsOn("addVersionResource")
-    options.release.set(11)
 }
 
-tasks.named<Test>("test") {
+tasks.withType<JavaCompile>().configureEach {
+    options.release.set(targetJavaVersion)
+}
+
+tasks.withType<Test>().configureEach {
     useJUnitPlatform()
+    javaLauncher.set(
+        javaToolchains.launcherFor {
+            languageVersion.set(testToolchainVersion)
+        }
+    )
 }
 
 spotless {


### PR DESCRIPTION
Similar to what was done on the main ODC project; helps insure the third party libs this project uses are working across Java versions.

Also 
- switches to the `-release` compiler flag, which is a bit safer than `-source`/`-target` since it uses the correct bootclasspath for the target JDK.
- fixes test report uploads
- pins github actions similar to done on ODC