### PR TITLE
fix(nvd): Accept high-precision and zoned timestamps (#106)

### DIFF
--- a/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/CveApiJson20.java
+++ b/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/CveApiJson20.java
@@ -72,7 +72,9 @@ public class CveApiJson20 implements Serializable {
      * (Required)
      */
     @JsonProperty("timestamp")
-    @JsonFormat(pattern = "uuuu-MM-dd'T'HH:mm:ss.SSS", timezone = "UTC")
+    // lenient on read: NVD emits timestamps with up to 9 fractional digits and/or a trailing zone offset;
+    // the getter pins serialization back to the 3-digit millisecond form for stable output.
+    @JsonFormat(pattern = "uuuu-MM-dd'T'HH:mm:ss[.[SSSSSSSSS][SSSSSSSS][SSSSSSS][SSSSSS][SSSSS][SSSS][SSS][SS][S]][XXX]", timezone = "UTC")
     private ZonedDateTime timestamp;
     /**
      * NVD feed array of CVE (Required)
@@ -164,6 +166,7 @@ public class CveApiJson20 implements Serializable {
      * @return timestamp
      */
     @JsonProperty("timestamp")
+    @JsonFormat(pattern = "uuuu-MM-dd'T'HH:mm:ss.SSS", timezone = "UTC")
     public ZonedDateTime getTimestamp() {
         return timestamp;
     }

--- a/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/CveItem.java
+++ b/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/CveItem.java
@@ -62,13 +62,15 @@ public class CveItem implements Serializable {
      * (Required)
      */
     @JsonProperty("published")
-    @JsonFormat(pattern = "uuuu-MM-dd'T'HH:mm:ss.SSS", timezone = "UTC")
+    // lenient on read: NVD emits timestamps with up to 9 fractional digits and/or a trailing zone offset;
+    // the getter pins serialization back to the 3-digit millisecond form for stable output.
+    @JsonFormat(pattern = "uuuu-MM-dd'T'HH:mm:ss[.[SSSSSSSSS][SSSSSSSS][SSSSSSS][SSSSSS][SSSSS][SSSS][SSS][SS][S]][XXX]", timezone = "UTC")
     private ZonedDateTime published;
     /**
      * (Required)
      */
     @JsonProperty("lastModified")
-    @JsonFormat(pattern = "uuuu-MM-dd'T'HH:mm:ss.SSS", timezone = "UTC")
+    @JsonFormat(pattern = "uuuu-MM-dd'T'HH:mm:ss[.[SSSSSSSSS][SSSSSSSS][SSSSSSS][SSSSSS][SSSSS][SSSS][SSS][SS][S]][XXX]", timezone = "UTC")
     private ZonedDateTime lastModified;
     @JsonProperty("evaluatorComment")
     private @Nullable String evaluatorComment;
@@ -209,6 +211,7 @@ public class CveItem implements Serializable {
      * @return published
      */
     @JsonProperty("published")
+    @JsonFormat(pattern = "uuuu-MM-dd'T'HH:mm:ss.SSS", timezone = "UTC")
     public ZonedDateTime getPublished() {
         return published;
     }
@@ -217,6 +220,7 @@ public class CveItem implements Serializable {
      * @return lastModified
      */
     @JsonProperty("lastModified")
+    @JsonFormat(pattern = "uuuu-MM-dd'T'HH:mm:ss.SSS", timezone = "UTC")
     public ZonedDateTime getLastModified() {
         return lastModified;
     }

--- a/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/VendorComment.java
+++ b/src/main/java/io/github/jeremylong/openvulnerability/client/nvd/VendorComment.java
@@ -55,7 +55,7 @@ public class VendorComment implements Serializable {
     @JsonProperty("lastModified")
     // the below format is a hack/workaround due to some poorly formatted dates in the NVD data, the getter corrects the
     // serialized format
-    @JsonFormat(pattern = "uuuu-MM-dd'T'HH:mm:ss[.[SSSSSSSSS][SSSSSSSS][SSSSSSS][SSSSSS][SSSSS][SSSS][SSS][SS][S]]", timezone = "UTC")
+    @JsonFormat(pattern = "uuuu-MM-dd'T'HH:mm:ss[.[SSSSSSSSS][SSSSSSSS][SSSSSSS][SSSSSS][SSSSS][SSSS][SSS][SS][S]][XXX]", timezone = "UTC")
     private ZonedDateTime lastModified;
 
     /**

--- a/src/test/java/io/github/jeremylong/openvulnerability/client/nvd/SerializationTest.java
+++ b/src/test/java/io/github/jeremylong/openvulnerability/client/nvd/SerializationTest.java
@@ -24,23 +24,21 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class SerializationTest {
 
+    private final ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+
     @Test
     void thereAndBackAgain() throws IOException {
-        ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.registerModule(new JavaTimeModule());
-        String json;
-        try (BufferedReader r = new BufferedReader(new InputStreamReader(
-                Objects.requireNonNull(this.getClass().getClassLoader().getResourceAsStream("nvd.json")),
-                StandardCharsets.UTF_8))) {
-            json = r.lines().collect(Collectors.joining("\n"));
-        }
+        String json = loadResource("nvd.json");
         CveApiJson20 current = objectMapper.readValue(json, CveApiJson20.class);
         assertEquals(2001, current.getVulnerabilities().size());
 
@@ -52,5 +50,41 @@ class SerializationTest {
         // String fixedInput = json.replaceAll("\\\\/","\\/")
         // .replaceAll("T00:00:00\\.00\"","T00:00:00.000\"");
         // assertTrue(fixedInput.equals(reserialized));
+    }
+
+    // Regression for #106: NVD API may return timestamps with up to 9 fractional-second digits and
+    // a trailing 'Z' zone offset; deserialization must accept them and serialize back to the
+    // canonical 3-digit millisecond form. The four timestamps inside nvd.json carry 9, 6, 6, 6
+    // digits of precision and use Z, +02:00, Z, +03:00 respectively, so the assertions also prove
+    // both lenient parsing and that each value lands on the correct property.
+    @Test
+    void deserializesHighPrecisionTimestamps() throws IOException {
+        String json = loadResource("nvd.json");
+
+        CveApiJson20 parsed = objectMapper.readValue(json, CveApiJson20.class);
+
+        assertEquals(ZonedDateTime.parse("2024-06-29T14:56:13.233888777Z"), parsed.getTimestamp());
+        CveItem cve = parsed.getVulnerabilities().get(0).getCve();
+        assertEquals(ZonedDateTime.parse("2023-09-04T02:15:09.243111+02:00").withZoneSameInstant(ZoneOffset.UTC),
+                cve.getPublished());
+        assertEquals(ZonedDateTime.parse("2023-09-08T00:04:49.200222Z"), cve.getLastModified());
+        assertEquals(ZonedDateTime.parse("2007-03-14T00:00:00.456789+03:00").withZoneSameInstant(ZoneOffset.UTC),
+                cve.getVendorComments().get(0).getLastModified());
+
+        // Serialized form drops the zone and truncates to three fractional digits; non-UTC inputs
+        // land as the equivalent UTC wall-clock time.
+        String reserialized = objectMapper.writeValueAsString(parsed);
+        assertTrue(reserialized.contains("\"timestamp\":\"2024-06-29T14:56:13.233\""));
+        assertTrue(reserialized.contains("\"published\":\"2023-09-04T00:15:09.243\""));
+        assertTrue(reserialized.contains("\"lastModified\":\"2023-09-08T00:04:49.200\""));
+        assertTrue(reserialized.contains("\"lastModified\":\"2007-03-13T21:00:00.456\""));
+    }
+
+    private String loadResource(String name) throws IOException {
+        try (BufferedReader r = new BufferedReader(new InputStreamReader(
+                Objects.requireNonNull(this.getClass().getClassLoader().getResourceAsStream(name)),
+                StandardCharsets.UTF_8))) {
+            return r.lines().collect(Collectors.joining("\n"));
+        }
     }
 }


### PR DESCRIPTION
NVD API 2.0 emits the top-level `timestamp` with 6–9 fractional-second digits and a trailing `Z` (e.g. `2026-04-15T15:37:42.736388Z`). The strict `@JsonFormat(pattern = "uuuu-MM-dd'T'HH:mm:ss.SSS")` fails with `InvalidFormatException: ... unparsed text found at index 23`, breaking every consumer (including `dependency-check-maven`) against the live API.

### Fix

Widen the deserialization patterns on the four NVD `ZonedDateTime` fields to accept 0–9 fractional digits and an optional `Z` / `+HH` / `+HH:MM` zone offset — the same lenient shape already used on `KevCatalog.dateReleased`:

```
uuuu-MM-dd'T'HH:mm:ss[.[SSSSSSSSS]…[S]][XXX]
```

Canonical serialization output (`uuuu-MM-dd'T'HH:mm:ss.SSS`, UTC) is preserved via strict `@JsonFormat` on the getters, so persisted `lastModified` watermarks and downstream consumers keep their existing on-disk format. `timezone = "UTC"` ensures zone-bearing inputs normalize to UTC on read.

### Changes

- `CveApiJson20.java` — `timestamp` field lenient on read, getter strict on write.
- `CveItem.java` — `published` / `lastModified` fields lenient, getters strict.
- `VendorComment.java` — `lastModified` field lenient (already had lenient fractional, adds optional zone offset).
- `src/test/resources/nvd.json` — four timestamps patched with realistic high-precision + zoned variants (9-digit `Z`, 6-digit `+02:00`, 6-digit `Z`, 6-digit `+03:00`); injected `vendorComments` block modeled on the real Red Hat comment on `CVE-1999-1572`. Schema cross-checked against a live fetch of `CVE-2023-38451` — no drift.
- `SerializationTest` — new `deserializesHighPrecisionTimestamps` asserts both lenient read and canonical write for all four timestamps; existing `thereAndBackAgain` fixed-point round-trip still passes on the higher-precision input.

GHSA, CISA KEV, and EPSS clients are intentionally left alone — empirical sampling (1,639 CVEs across `pubStartDate` and `lastModStartDate` windows) shows only the NVD top-level `timestamp` currently emits sub-second precision beyond 3 digits, and hardening the other clients would require adding getter-level serialization overrides they don't currently have.

Fixes #106