### PR TITLE
Add additional edge case tests for parseResultsPerPage

### DIFF
--- a/src/test/java/io/github/jeremylong/openvulnerability/client/nvd/NvdCveClientTest.java
+++ b/src/test/java/io/github/jeremylong/openvulnerability/client/nvd/NvdCveClientTest.java
@@ -26,8 +26,35 @@ class NvdCveClientTest {
     void parseResultsPerPageTest() {
         try (NvdCveClient client = new NvdCveClient(null, null, 1, 1)) {
             client.setResultsPerPage(2000);
-            int recordsPerPage = client.parseResultsPerPage("resultsPerPage parameter cannot exceed 1000.");
-            assertEquals(1000, recordsPerPage, "Incorrect records per page value parsed");
+            int recordsPerPage = client.parseResultsPerPage(
+                    "resultsPerPage parameter cannot exceed 1000.");
+            assertEquals(1000, recordsPerPage,
+                    "Incorrect records per page value parsed");
+        }
+    }
+
+        @Test
+    void parseResultsPerPageInvalidNumberTest() {
+        try (NvdCveClient client = new NvdCveClient(null, null, 1, 1)) {
+            client.setResultsPerPage(2000);
+
+            int recordsPerPage = client.parseResultsPerPage(
+                    "resultsPerPage parameter cannot exceed abc."
+            );
+
+            assertEquals(2000, recordsPerPage,
+                    "Should return configured resultsPerPage on parse failure");
+        }
+    }
+
+    @Test
+    void parseResultsPerPageWithoutPeriodTest() {
+        try (NvdCveClient client = new NvdCveClient(null, null, 1, 1)) {
+            int recordsPerPage = client.parseResultsPerPage(
+                    "resultsPerPage parameter cannot exceed 500");
+
+            assertEquals(500, recordsPerPage,
+                    "Incorrect records per page value parsed");
         }
     }
 }

--- a/src/test/java/io/github/jeremylong/openvulnerability/client/nvd/NvdCveClientTest.java
+++ b/src/test/java/io/github/jeremylong/openvulnerability/client/nvd/NvdCveClientTest.java
@@ -33,7 +33,7 @@ class NvdCveClientTest {
         }
     }
 
-        @Test
+    @Test
     void parseResultsPerPageInvalidNumberTest() {
         try (NvdCveClient client = new NvdCveClient(null, null, 1, 1)) {
             client.setResultsPerPage(2000);


### PR DESCRIPTION
This PR adds additional unit tests for `NvdCveClient.parseResultsPerPage()`.

Changes:

* Added a test for parsing values when the error message does not end with a period.
* Added a test to verify fallback behavior when the parsed value is not numeric.

All tests pass successfully.
